### PR TITLE
Upgrade Android Gradle Plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
 
     alias(libs.plugins.android.application)
@@ -9,6 +11,12 @@ plugins {
     alias(libs.plugins.ktlint.gradle)
     id("kotlin-parcelize")
     id("com.google.android.gms.oss-licenses-plugin")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
+    }
 }
 
 android {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,6 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
 
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.baselineprofile)
@@ -12,12 +9,6 @@ plugins {
     alias(libs.plugins.ktlint.gradle)
     id("kotlin-parcelize")
     id("com.google.android.gms.oss-licenses-plugin")
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
-    }
 }
 
 android {

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,6 +1,14 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.test)
     alias(libs.plugins.baselineprofile)
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
+    }
 }
 
 android {

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,15 +1,6 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.android.test)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.baselineprofile)
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
-    }
 }
 
 android {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 activity-compose = "1.12.2"
-agp = "8.13.2"
+agp = "9.3.0-alpha07"
 annotation = "1.9.1"
 ksp = "2.3.8"
 androidx-junit = "1.3.0"
 appcompat = "1.7.1"
-benchmark = "1.4.1"
+benchmark = "1.5.0-alpha06"
 coil = "3.3.0"
 compose-bom = "2026.05.01"
 compose-material3 = "1.4.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Upgrades the Android Gradle Plugin and compatible build tooling.

Changes:
- AGP 8.13.2 -> 9.3.0-alpha07
- Gradle wrapper 9.1.0 -> 9.5.0
- AndroidX benchmark/baselineprofile 1.4.1 -> 1.5.0-alpha06
- Removes org.jetbrains.kotlin.android from Android app/test modules for AGP 9 built-in Kotlin

Validation:
- :app:compileDebugKotlin
- :app:testDebugUnitTest
- :app:assembleDebug
- :app:installDebug on connected device