### PR TITLE
Fix watchlist paging duplicate keys

### DIFF
--- a/app/src/main/java/com/anod/appwatcher/database/AppListTable.kt
+++ b/app/src/main/java/com/anod/appwatcher/database/AppListTable.kt
@@ -293,6 +293,7 @@ interface AppListTable {
                 Preferences.SORT_DATE_DESC -> filter.add(Columns.UPLOAD_TIMESTAMP + " DESC")
                 else -> filter.add(Columns.TITLE + " COLLATE NOCASE ASC")
             }
+            filter.add("$TABLE.${BaseColumns._ID} ASC")
             return filter.joinToString(", ")
         }
 

--- a/app/src/main/java/com/anod/appwatcher/watchlist/Section.kt
+++ b/app/src/main/java/com/anod/appwatcher/watchlist/Section.kt
@@ -78,7 +78,7 @@ sealed interface SectionItem {
 
     @Immutable
     class OnDevice(val appListItem: AppListItem, var showSelection: Boolean, val packageInfo: InstalledApps.Info) : SectionItem {
-        override val sectionKey = "ondevice-{appListItem.app.rowId}:${hashCode()}"
+        override val sectionKey = "ondevice-${appListItem.app.rowId}:${hashCode()}"
         override val contentType = "OnDevice"
         val changesHtml: String = appListItem.cleanChangeHtml()
 

--- a/app/src/main/java/com/anod/appwatcher/watchlist/WatchListPagerFactory.kt
+++ b/app/src/main/java/com/anod/appwatcher/watchlist/WatchListPagerFactory.kt
@@ -42,6 +42,10 @@ abstract class WatchListPagerFactory(val pagingSourceConfig: WatchListPagingSour
     abstract fun createPagingSource(): FilterablePagingSource
     abstract fun createSectionHeaderFactory(): SectionHeaderFactory
 
+    fun invalidatePagingSource() {
+        pagingSource?.invalidate()
+    }
+
     private fun createPager(): Flow<PagingData<SectionItem>> {
         headerFactory = createSectionHeaderFactory()
 

--- a/app/src/main/java/com/anod/appwatcher/watchlist/WatchListStateViewModel.kt
+++ b/app/src/main/java/com/anod/appwatcher/watchlist/WatchListStateViewModel.kt
@@ -106,6 +106,7 @@ sealed interface WatchListEvent {
     class SectionHeaderClick(val type: SectionHeader) : WatchListEvent
 }
 
+
 sealed interface WatchListTagFilter {
     data object None : WatchListTagFilter
     data object Untagged : WatchListTagFilter
@@ -233,8 +234,11 @@ class WatchListStateViewModel(
                 .drop(1)
                 .map { (System.currentTimeMillis() / 1000).toInt() }
                 .filter { it > 0 }
-                .onEach { delay(600) }
                 .flowOn(Dispatchers.Default)
+                .onEach {
+                    invalidatePagingSources()
+                    delay(600)
+                }
                 .collect {
                     viewState = viewState.copy(dbAppsChange = viewState.dbAppsChange + 1)
                 }
@@ -389,5 +393,11 @@ class WatchListStateViewModel(
         )
         installedApps.reset()
         SyncScheduler(application).execute().first()
+    }
+
+    private fun invalidatePagingSources() {
+        _pagerFactories.values.toList().forEach { pagerFactory ->
+            pagerFactory.invalidatePagingSource()
+        }
     }
 }

--- a/app/src/test/java/com/anod/appwatcher/watchlist/WatchListPagingSourceTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/watchlist/WatchListPagingSourceTest.kt
@@ -1,7 +1,12 @@
+// Copyright (c) 2026. Alex Gavrishev
 package com.anod.appwatcher.watchlist
 
+import androidx.paging.PagingState
+import com.anod.appwatcher.model.Filters
+import kotlinx.coroutines.CoroutineScope
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.coroutines.EmptyCoroutineContext
 
 // Unit tests for WatchListPagingSource helper logic.
 class WatchListPagingSourceTest {
@@ -156,5 +161,53 @@ class WatchListPagingSourceTest {
         assertEquals(20, WatchListPagingSource.calculateItemsBefore(19, showRecentlyInstalled = true))
         assertEquals(40, WatchListPagingSource.calculateItemsBefore(39, showRecentlyInstalled = true))
         assertEquals(20, WatchListPagingSource.calculateItemsBefore(20, showRecentlyInstalled = false))
+    }
+
+    @Test
+    fun `pager factory invalidates active paging source`() {
+        val source = TestPagingSource()
+        var invalidated = false
+        source.registerInvalidatedCallback {
+            invalidated = true
+        }
+
+        val factory = TestPagerFactory()
+        factory.attach(source)
+        factory.invalidatePagingSource()
+
+        assertEquals(true, invalidated)
+    }
+
+    private class TestPagerFactory : WatchListPagerFactory(
+        pagingSourceConfig = WatchListPagingSource.Config(
+            filterId = Filters.ALL,
+            tagId = null,
+            showRecentlyDiscovered = false,
+            showOnDevice = false,
+            showRecentlyInstalled = false,
+        ),
+        cacheScope = CoroutineScope(EmptyCoroutineContext)
+    ) {
+        fun attach(source: TestPagingSource) {
+            pagingSource = source
+        }
+
+        override fun createPagingSource(): FilterablePagingSource = TestPagingSource()
+
+        override fun createSectionHeaderFactory(): SectionHeaderFactory = SectionHeaderFactory.Empty()
+    }
+
+    private class TestPagingSource : FilterablePagingSource() {
+        override var filterQuery: String = ""
+
+        override fun getRefreshKey(state: PagingState<Int, SectionItem>): Int? = null
+
+        override suspend fun load(params: LoadParams<Int>): LoadResult<Int, SectionItem> {
+            return LoadResult.Page(
+                data = emptyList(),
+                prevKey = null,
+                nextKey = null
+            )
+        }
     }
 }


### PR DESCRIPTION
Ensure watchlist app queries use a deterministic row-id tie-breaker and invalidate active custom PagingSources as soon as app rows change, before the delayed UI refresh token update. Also fix the on-device section key row-id interpolation and cover PagingSource invalidation with a focused unit test.