### PR TITLE
Update worktree instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,7 @@
 ## Build, test, and lint
 
 - Setup: `git submodule update --init --recursive`, `local.properties` with `sdk.dir=...`, and `app/google-services.json` from `google-services.json.debug`.
+- In task worktrees, copy ignored local build inputs from the main checkout before building: `local.properties`, `app/google-services.json` when present, and any other required local/private files. Keep these files untracked and do not print their contents.
 - Commands:
   - Build debug APK: `./gradlew :app:assembleDebug`
   - Install/deploy debug APK to a connected device: `./gradlew :app:installDebug`
@@ -30,6 +31,8 @@
 ## Worktree workflow
 
 - Work only in a dedicated git worktree for every task; keep the main checkout on `master` for coordination and branch management.
+- Create task worktrees inside the main checkout's ignored `wt/` folder, for example `git worktree add -b <branch> wt/<branch> origin/master` (Windows: `wt\<branch>`).
+- After creating a task worktree, copy necessary ignored local build files from the main checkout into the same relative paths in the task worktree, especially `local.properties` and `app/google-services.json` when available.
 - When the task branch/PR has been merged, remove the task worktree with `git worktree remove <path>` and run `git worktree prune` to delete stale metadata.
 - If a task changes a submodule pointer, commit and push the submodule repository first, then verify the exact SHA is fetchable from its remote before committing or opening/pushing the parent AppWatcher PR.
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ app/google-services.json
 /src/main/res/raw/third_party_license_metadata
 /src/main/res/raw/third_party_licenses
 .kotlin
+/wt/


### PR DESCRIPTION
## Summary
- document creating task worktrees under the ignored wt/ folder
- document copying ignored local build inputs into task worktrees before building
- ignore the local wt/ workspace folder