### PR TITLE
Fix repeated update notifications after dismiss

### DIFF
--- a/app/src/main/java/com/anod/appwatcher/NotificationActivity.kt
+++ b/app/src/main/java/com/anod/appwatcher/NotificationActivity.kt
@@ -14,20 +14,29 @@ import info.anodsplace.framework.content.startActivitySafely
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
+internal const val NOTIFICATION_ACTION_PLAY_STORE = 1
+internal const val NOTIFICATION_ACTION_DISMISS = 2
+internal const val NOTIFICATION_ACTION_MY_APPS = 3
+internal const val NOTIFICATION_ACTION_MARK_VIEWED = 4
+
+internal fun shouldMarkUpdatesViewed(actionType: Int) =
+    actionType == NOTIFICATION_ACTION_DISMISS || actionType == NOTIFICATION_ACTION_MARK_VIEWED
+
 class NotificationActivity : Activity(), KoinComponent {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val sn = SyncNotification(info.anodsplace.context.ApplicationContext(this), get())
         sn.cancel()
-        when (intent.getIntExtra(EXTRA_ACTION_TYPE, 0)) {
+        val actionType = intent.getIntExtra(EXTRA_ACTION_TYPE, 0)
+        when (actionType) {
             ACTION_PLAY_STORE -> {
                 val pkg = intent.getStringExtra(EXTRA_PACKAGE) ?: ""
                 startActivitySafely(Intent().forPlayStore(pkg).addMultiWindowFlags(this))
             }
 
             ACTION_MY_APPS -> startActivitySafely(Intent().forMyApps(false).addMultiWindowFlags(this))
-            ACTION_MARK_VIEWED -> {
+            else -> if (shouldMarkUpdatesViewed(actionType)) {
                 prefs.isLastUpdatesViewed = true
             }
         }
@@ -38,10 +47,10 @@ class NotificationActivity : Activity(), KoinComponent {
         private const val EXTRA_ACTION_TYPE = "type"
         const val EXTRA_PACKAGE = "pkg"
 
-        const val ACTION_PLAY_STORE = 1
-        const val ACTION_DISMISS = 2
-        const val ACTION_MY_APPS = 3
-        const val ACTION_MARK_VIEWED = 4
+        const val ACTION_PLAY_STORE = NOTIFICATION_ACTION_PLAY_STORE
+        const val ACTION_DISMISS = NOTIFICATION_ACTION_DISMISS
+        const val ACTION_MY_APPS = NOTIFICATION_ACTION_MY_APPS
+        const val ACTION_MARK_VIEWED = NOTIFICATION_ACTION_MARK_VIEWED
 
         fun intent(uri: Uri, type: Int, context: Context) = Intent(context, NotificationActivity::class.java)
             .apply {

--- a/app/src/main/java/com/anod/appwatcher/sync/SyncNotification.kt
+++ b/app/src/main/java/com/anod/appwatcher/sync/SyncNotification.kt
@@ -104,6 +104,9 @@ class SyncNotification(private val context: ApplicationContext, private val noti
             .setContentTitle(title)
             .setContentText(text)
             .setContentIntent(contentIntent)
+            .setDeleteIntent(
+                markViewedPendingIntent(Uri.parse("com.anod.appwatcher://dismiss/"), NotificationActivity.ACTION_DISMISS)
+            )
             .setTicker(title)
 
         if (!DynamicColors.isDynamicColorAvailable()) {
@@ -141,7 +144,7 @@ class SyncNotification(private val context: ApplicationContext, private val noti
             context.actual
         )
         builder.addAction(R.drawable.ic_clear_white_24dp, context.getString(R.string.dismiss),
-            PendingIntent.getActivity(context.actual, 0, readIntent, PendingIntent.FLAG_IMMUTABLE)
+            markViewedPendingIntent(readIntent)
         )
     }
 
@@ -177,9 +180,15 @@ class SyncNotification(private val context: ApplicationContext, private val noti
             NotificationActivity.ACTION_MARK_VIEWED,
             context.actual)
         builder.addAction(R.drawable.ic_clear_white_24dp, context.getString(R.string.dismiss),
-            PendingIntent.getActivity(context.actual, 0, readIntent, PendingIntent.FLAG_IMMUTABLE)
+            markViewedPendingIntent(readIntent)
         )
     }
+
+    private fun markViewedPendingIntent(intent: Intent): PendingIntent =
+        PendingIntent.getActivity(context.actual, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+
+    private fun markViewedPendingIntent(uri: Uri, action: Int): PendingIntent =
+        markViewedPendingIntent(NotificationActivity.intent(uri, action, context.actual))
 
     private fun renderText(apps: List<UpdatedApp>): String {
         val count = apps.size

--- a/app/src/test/java/com/anod/appwatcher/NotificationActivityTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/NotificationActivityTest.kt
@@ -1,0 +1,20 @@
+package com.anod.appwatcher
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NotificationActivityTest {
+
+    @Test
+    fun dismissActionsMarkUpdatesViewed() {
+        assertTrue(shouldMarkUpdatesViewed(NOTIFICATION_ACTION_DISMISS))
+        assertTrue(shouldMarkUpdatesViewed(NOTIFICATION_ACTION_MARK_VIEWED))
+    }
+
+    @Test
+    fun navigationActionsDoNotMarkUpdatesViewed() {
+        assertFalse(shouldMarkUpdatesViewed(NOTIFICATION_ACTION_PLAY_STORE))
+        assertFalse(shouldMarkUpdatesViewed(NOTIFICATION_ACTION_MY_APPS))
+    }
+}


### PR DESCRIPTION
## Summary
- mark update notifications viewed when the Dismiss action is used
- add a delete intent so swiping a notification away also marks updates viewed
- add a regression test for notification action read-state mapping

## Validation
- .\gradlew.bat :app:testDebugUnitTest
- .\gradlew.bat :app:ktlintMainSourceSetCheck :app:ktlintTestSourceSetCheck

Note: full .\gradlew.bat ktlintCheck is blocked by a pre-existing final-newline violation in app\build.gradle.kts.