### PR TITLE
Fix Android 15 ghost updates and Play devices

### DIFF
--- a/app/src/androidTest/java/com/anod/appwatcher/AppWatcherSmokeTest.kt
+++ b/app/src/androidTest/java/com/anod/appwatcher/AppWatcherSmokeTest.kt
@@ -135,21 +135,22 @@ class AppWatcherSmokeTest {
 
     companion object {
         private const val PREFS_NAME = "WatcherPrefs"
+        private const val DEVICE_PREFS_NAME = "DeviceRegistration"
         private lateinit var preferences: SharedPreferences
+        private lateinit var devicePreferences: SharedPreferences
         private var originalPrefs: Map<String, Any?> = emptyMap()
+        private var originalDevicePrefs: Map<String, Any?> = emptyMap()
 
         @JvmStatic
         @BeforeClass
         fun configureStableStartupState() {
             val context = InstrumentationRegistry.getInstrumentation().targetContext
             preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            devicePreferences = context.getSharedPreferences(DEVICE_PREFS_NAME, Context.MODE_PRIVATE)
             originalPrefs = HashMap<String, Any?>(preferences.all)
+            originalDevicePrefs = HashMap<String, Any?>(devicePreferences.all)
+            devicePreferences.edit().clear().commit()
             preferences.edit()
-                .remove("account_name")
-                .remove("account_type")
-                .remove("gfs_id")
-                .remove("gfs_token")
-                .remove("device_config")
                 .putInt("update_frequency", 0)
                 .putBoolean("crash-reports", false)
                 .commit()
@@ -158,8 +159,16 @@ class AppWatcherSmokeTest {
         @JvmStatic
         @AfterClass
         fun restoreStartupState() {
+            restorePreferences(preferences, originalPrefs)
+            restorePreferences(devicePreferences, originalDevicePrefs)
+        }
+
+        private fun restorePreferences(
+            preferences: SharedPreferences,
+            values: Map<String, Any?>
+        ) {
             val editor = preferences.edit().clear()
-            originalPrefs.forEach { (key, value) ->
+            values.forEach { (key, value) ->
                 when (value) {
                     is Boolean -> editor.putBoolean(key, value)
                     is Float -> editor.putFloat(key, value)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,9 +35,14 @@
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
 
     <application
+        android:allowBackup="true"
         android:name=".AppWatcherApplication"
+        android:backupAgent=".backup.AppWatcherBackupAgent"
+        android:fullBackupOnly="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:supportsRtl="false"
         android:theme="@style/AppTheme.Main"
         android:localeConfig="@xml/locales_config"

--- a/app/src/main/java/com/anod/appwatcher/AppModule.kt
+++ b/app/src/main/java/com/anod/appwatcher/AppModule.kt
@@ -9,6 +9,7 @@ import coil3.ImageLoader
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import com.anod.appwatcher.accounts.AuthAccountInitializer
 import com.anod.appwatcher.accounts.AuthTokenBlocking
+import com.anod.appwatcher.accounts.PlaySessionCoordinator
 import com.anod.appwatcher.backup.gdrive.UploadServiceContentObserver
 import com.anod.appwatcher.preferences.Preferences
 import com.anod.appwatcher.sync.UpdateCheck
@@ -45,6 +46,7 @@ fun createAppModule(): Module = module {
         )
     }
     factory { get<Application>().packageManager }
+    singleOf(::PlaySessionCoordinator)
     singleOf(::AuthAccountInitializer)
     singleOf(::UploadDateParserCache)
     singleOf(::ApplicationContext)
@@ -89,6 +91,7 @@ fun createAppModule(): Module = module {
             authAccount = get(),
             networkConnection = get(),
             preferences = get(),
+            playSessionCoordinator = get(),
             uploadDateParserCache = get(),
             koin = getKoin()
         )

--- a/app/src/main/java/com/anod/appwatcher/PlaystoreModule.kt
+++ b/app/src/main/java/com/anod/appwatcher/PlaystoreModule.kt
@@ -1,5 +1,6 @@
 package com.anod.appwatcher
 
+import com.anod.appwatcher.accounts.AuthRecoveringDfeApi
 import com.anod.appwatcher.utils.DeviceInfoProvider
 import com.anod.appwatcher.utils.PlaystoreAuthTokenProvider
 import finsky.api.DfeApi
@@ -13,14 +14,18 @@ import org.koin.dsl.module
 fun createPlayStoreModule(): Module = module {
     singleOf(::DeviceInfoProvider) { bind<DfeDeviceInfoProvider>() }
     factory<DfeApi> {
-        DfeApiImpl(
-            http = get(),
-            context = get(),
-            authTokenProvider = PlaystoreAuthTokenProvider(
-                authTokenBlocking = get(),
-                preferences = get()
+        AuthRecoveringDfeApi(
+            delegate = DfeApiImpl(
+                http = get(),
+                context = get(),
+                authTokenProvider = PlaystoreAuthTokenProvider(
+                    authTokenBlocking = get(),
+                    preferences = get()
+                ),
+                deviceInfoProvider = get()
             ),
-            deviceInfoProvider = get()
+            authToken = get(),
+            preferences = get()
         )
     }
 }

--- a/app/src/main/java/com/anod/appwatcher/accounts/AuthAccountInitializer.kt
+++ b/app/src/main/java/com/anod/appwatcher/accounts/AuthAccountInitializer.kt
@@ -1,6 +1,7 @@
 package com.anod.appwatcher.accounts
 
 import android.accounts.Account
+import android.os.Build
 import com.anod.appwatcher.preferences.Preferences
 import finsky.api.DfeApi
 import info.anodsplace.applog.AppLog
@@ -10,30 +11,52 @@ import kotlinx.coroutines.sync.withLock
 class AuthTokenUnavailableException : IllegalStateException("Unable to retrieve authentication token")
 class AccountSessionBusyException : IllegalStateException("A Play Store synchronization is in progress")
 
-class AuthAccountInitializer(private val preferences: Preferences, private val authToken: AuthTokenBlocking, private val dfeApi: DfeApi) {
-    private val deviceRegistration = DeviceRegistration(preferences, dfeApi)
-    private val accountMutex = Mutex()
+class PlaySessionCoordinator {
+    private val sessionMutex = Mutex()
 
-    suspend fun initialize(
-        account: Account,
-        userInitiated: Boolean = false
-    ): AuthAccount {
-        if (!userInitiated) {
-            return accountMutex.withLock {
-                initializeLocked(account, userInitiated = false)
-            }
-        }
-        if (!accountMutex.tryLock()) {
+    suspend fun <T> withSession(action: suspend () -> T): T = sessionMutex.withLock {
+        action()
+    }
+
+    suspend fun <T> withUserInitiatedSession(action: suspend () -> T): T {
+        if (!sessionMutex.tryLock()) {
             throw AccountSessionBusyException()
         }
         return try {
-            initializeLocked(account, userInitiated = true)
+            action()
         } finally {
-            accountMutex.unlock()
+            sessionMutex.unlock()
         }
     }
+}
 
-    private suspend fun initializeLocked(
+class AuthAccountInitializer(
+    private val preferences: Preferences,
+    private val authToken: AuthTokenBlocking,
+    private val dfeApi: DfeApi,
+    private val playSessionCoordinator: PlaySessionCoordinator
+) {
+    private val deviceRegistration = DeviceRegistration(
+        preferences = preferences,
+        dfeApi = dfeApi,
+        sdkInt = Build.VERSION.SDK_INT
+    )
+
+    suspend fun initialize(
+        account: Account,
+        userInitiated: Boolean
+    ): AuthAccount =
+        if (userInitiated) {
+            playSessionCoordinator.withUserInitiatedSession {
+                initializeInSession(account, userInitiated = true)
+            }
+        } else {
+            playSessionCoordinator.withSession {
+                initializeInSession(account, userInitiated = false)
+            }
+        }
+
+    private suspend fun initializeInSession(
         account: Account,
         userInitiated: Boolean
     ): AuthAccount {
@@ -58,7 +81,9 @@ class AuthAccountInitializer(private val preferences: Preferences, private val a
         check(
             preferences.saveAccount(
                 selectedAccount,
-                deviceRegistrationAuthorized = if (userInitiated) authorizeRegistration else null
+                deviceRegistrationPending = null,
+                deviceRegistrationAuthorized = if (userInitiated) authorizeRegistration else null,
+                deviceConfigRevision = null
             )
         ) {
             "Unable to persist selected account"
@@ -84,15 +109,16 @@ class AuthAccountInitializer(private val preferences: Preferences, private val a
     }
 
     suspend fun refresh() {
-        withRefreshedAccount { }
+        playSessionCoordinator.withSession {
+            refreshInSession()
+        }
     }
 
-    internal suspend fun <T> withRefreshedAccount(action: suspend (AuthAccount) -> T): T = accountMutex.withLock {
+    internal suspend fun refreshInSession(): AuthAccount {
         val account = preferences.account ?: throw IllegalStateException("Account should not be null")
         val androidAccount = account.toAndroidAccount()
         requireToken(authToken.refreshToken(androidAccount))
-        val refreshedAccount = deviceRegistration.ensure(account, allowCheckIn = false)
-        action(refreshedAccount)
+        return deviceRegistration.ensure(account, allowCheckIn = false)
     }
 
     private fun requireToken(result: CheckTokenResult) {

--- a/app/src/main/java/com/anod/appwatcher/accounts/AuthAccountInitializer.kt
+++ b/app/src/main/java/com/anod/appwatcher/accounts/AuthAccountInitializer.kt
@@ -1,97 +1,111 @@
 package com.anod.appwatcher.accounts
 
 import android.accounts.Account
-import android.os.Build
 import com.anod.appwatcher.preferences.Preferences
 import finsky.api.DfeApi
-import finsky.api.toDocument
 import info.anodsplace.applog.AppLog
-import java.math.BigInteger
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class AuthTokenUnavailableException : IllegalStateException("Unable to retrieve authentication token")
+class AccountSessionBusyException : IllegalStateException("A Play Store synchronization is in progress")
 
 class AuthAccountInitializer(private val preferences: Preferences, private val authToken: AuthTokenBlocking, private val dfeApi: DfeApi) {
-    suspend fun initialize(account: Account): AuthAccount {
-        val existingAccount = preferences.account
-        val tokenResult = try {
-            authToken.refreshToken(account)
+    private val deviceRegistration = DeviceRegistration(preferences, dfeApi)
+    private val accountMutex = Mutex()
+
+    suspend fun initialize(
+        account: Account,
+        userInitiated: Boolean = false
+    ): AuthAccount {
+        if (!userInitiated) {
+            return accountMutex.withLock {
+                initializeLocked(account, userInitiated = false)
+            }
+        }
+        if (!accountMutex.tryLock()) {
+            throw AccountSessionBusyException()
+        }
+        return try {
+            initializeLocked(account, userInitiated = true)
+        } finally {
+            accountMutex.unlock()
+        }
+    }
+
+    private suspend fun initializeLocked(
+        account: Account,
+        userInitiated: Boolean
+    ): AuthAccount {
+        val activeAccount = preferences.account
+        if (
+            !userInitiated &&
+            activeAccount != null &&
+            (activeAccount.name != account.name || activeAccount.type != account.type)
+        ) {
+            return activeAccount
+        }
+        val existingAccount = activeAccount
+        val selectedAccount = if (
+            existingAccount?.name == account.name &&
+            existingAccount.type == account.type
+        ) {
+            existingAccount
+        } else {
+            AuthAccount(account, preferences.deviceIdentity, "")
+        }
+        val authorizeRegistration = userInitiated && selectedAccount.gfsId.isEmpty()
+        check(
+            preferences.saveAccount(
+                selectedAccount,
+                deviceRegistrationAuthorized = if (userInitiated) authorizeRegistration else null
+            )
+        ) {
+            "Unable to persist selected account"
+        }
+        val allowCheckIn = userInitiated || preferences.isDeviceRegistrationAuthorized
+
+        try {
+            requireToken(authToken.refreshToken(account))
+        } catch (e: AuthTokenStartIntent) {
+            throw e
         } catch (e: Exception) {
+            clearDeviceRegistrationAuthorization()
             AppLog.d("Exception during token refresh. Persisting account anyway, ${e.message}")
-            preferences.account = AuthAccount(account, GfsIdResult("", ""), "")
             throw e
         }
-        val isNewAccount = existingAccount?.name != account.name
-        var gfsIdResult: GfsIdResult? = if (isNewAccount) null else existingAccount?.toGfsResult()
-        var deviceConfigToken: String? = if (isNewAccount) null else existingAccount?.deviceConfig
-        if (needToRetrieveGfsId(existingAccount, account, tokenResult)) {
-            gfsIdResult = try {
-                retrieveGsfId()
-            } catch (e: Exception) {
-                AppLog.e("Unable to generate gfs Id ${e.message}")
-                GfsIdResult("", "")
-            }
-            deviceConfigToken = try {
-                dfeApi.uploadDeviceConfig().uploadDeviceConfigToken
-            } catch (e: Exception) {
-                AppLog.e("Unable to upload device config ${e.message}")
-                ""
-            }
-        }
-        val authAccount = AuthAccount(
-            account,
-            gfsIdResult ?: GfsIdResult("", ""),
-            deviceConfigToken ?: ""
+
+        clearDeviceRegistrationAuthorization()
+        val authAccount = deviceRegistration.ensure(
+            selectedAccount,
+            allowCheckIn = allowCheckIn
         )
-        preferences.account = authAccount
         return authAccount
     }
 
     suspend fun refresh() {
+        withRefreshedAccount { }
+    }
+
+    internal suspend fun <T> withRefreshedAccount(action: suspend (AuthAccount) -> T): T = accountMutex.withLock {
         val account = preferences.account ?: throw IllegalStateException("Account should not be null")
         val androidAccount = account.toAndroidAccount()
-        val tokenResult = authToken.refreshToken(androidAccount)
-        if (needToRetrieveGfsId(account, androidAccount, tokenResult)) {
-            val gfsIdResult = retrieveGsfId()
-            val deviceConfigToken = dfeApi.uploadDeviceConfig().uploadDeviceConfigToken
-            val authAccount = AuthAccount(androidAccount, gfsIdResult, deviceConfigToken)
-            preferences.account = authAccount
+        requireToken(authToken.refreshToken(androidAccount))
+        val refreshedAccount = deviceRegistration.ensure(account, allowCheckIn = false)
+        action(refreshedAccount)
+    }
+
+    private fun requireToken(result: CheckTokenResult) {
+        if (result !is CheckTokenResult.Success) {
+            throw AuthTokenUnavailableException()
         }
     }
 
-    private suspend fun needToRetrieveGfsId(existingAccount: AuthAccount?, newAccount: Account, tokenResult: CheckTokenResult): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            return false
+    internal suspend fun clearDeviceRegistrationAuthorization() {
+        if (preferences.isDeviceRegistrationAuthorized) {
+            check(preferences.saveDeviceRegistrationAuthorization(false)) {
+                "Unable to persist device registration authorization"
+            }
         }
-        val tokenInvalidated = if (tokenResult is CheckTokenResult.Success) tokenResult.invalidated else false
-        return existingAccount == null ||
-            existingAccount.deviceConfig.isEmpty() ||
-            existingAccount.name != newAccount.name ||
-            tokenInvalidated ||
-            !canRequest()
-    }
-
-    private suspend fun canRequest(): Boolean {
-        if (preferences.account == null) {
-            return false
-        }
-        return try {
-            val app = dfeApi.details("details?doc=com.anod.appwatcher").toDocument()
-            val result = app?.appDetails?.packageName == "com.anod.appwatcher"
-            AppLog.d("Auth verification result: $result")
-            result
-        } catch (e: Exception) {
-            AppLog.d("Auth verification failed $e")
-            false
-        }
-    }
-
-    private suspend fun retrieveGsfId(): GfsIdResult {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            return GfsIdResult("", "")
-        }
-        val response = dfeApi.checkIn()
-        if (response.androidId == 0L) {
-            throw IllegalStateException("Incorrect androidId")
-        }
-        val gsfId = BigInteger.valueOf(response.androidId).toString(16)
-        return GfsIdResult(gsfId, response.deviceCheckinConsistencyToken ?: "")
     }
 }

--- a/app/src/main/java/com/anod/appwatcher/accounts/AuthRecoveringDfeApi.kt
+++ b/app/src/main/java/com/anod/appwatcher/accounts/AuthRecoveringDfeApi.kt
@@ -1,0 +1,91 @@
+package com.anod.appwatcher.accounts
+
+import com.anod.appwatcher.preferences.Preferences
+import finsky.api.BulkDocId
+import finsky.api.DfeApi
+import finsky.api.DfeDeviceIdentity
+import finsky.api.DfeServerError
+import finsky.api.PatchFormat
+import finsky.protos.AndroidCheckinResponse
+import finsky.protos.DeliveryResponse
+import finsky.protos.Details
+import finsky.protos.ResponseWrapper
+import finsky.protos.UploadDeviceConfigResponse
+
+internal class AuthRecoveringDfeApi(
+    private val delegate: DfeApi,
+    private val authToken: AuthTokenBlocking,
+    private val preferences: Preferences
+) : DfeApi {
+    override val authenticated: Boolean
+        get() = delegate.authenticated
+
+    override suspend fun search(initialQuery: String, nextPageUrl: String): ResponseWrapper =
+        withAuthenticationRecovery { delegate.search(initialQuery, nextPageUrl) }
+
+    override suspend fun details(appDetailsUrl: String): Details.DetailsResponse =
+        withAuthenticationRecovery { delegate.details(appDetailsUrl) }
+
+    override suspend fun details(
+        docIds: List<BulkDocId>,
+        includeDetails: Boolean
+    ): Details.BulkDetailsResponse =
+        withAuthenticationRecovery { delegate.details(docIds, includeDetails) }
+
+    override suspend fun delivery(
+        docId: String,
+        installedVersionCode: Int,
+        updateVersionCode: Int,
+        offerType: Int,
+        patchFormats: Array<PatchFormat>
+    ): DeliveryResponse = withAuthenticationRecovery {
+        delegate.delivery(
+            docId,
+            installedVersionCode,
+            updateVersionCode,
+            offerType,
+            patchFormats
+        )
+    }
+
+    override suspend fun wishlist(nextPageUrl: String): ResponseWrapper =
+        withAuthenticationRecovery { delegate.wishlist(nextPageUrl) }
+
+    override suspend fun purchaseHistory(nextPageUrl: String): ResponseWrapper =
+        withAuthenticationRecovery { delegate.purchaseHistory(nextPageUrl) }
+
+    override suspend fun checkIn(): AndroidCheckinResponse = delegate.checkIn()
+
+    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity?): UploadDeviceConfigResponse =
+        withAuthenticationRecovery { delegate.uploadDeviceConfig(identity) }
+
+    private suspend fun <T> withAuthenticationRecovery(request: suspend () -> T): T {
+        val account = preferences.account
+        val rejectedToken = authToken.tokenFor(account)
+        try {
+            return request()
+        } catch (e: DfeServerError) {
+            if (
+                !e.isAuthenticationError ||
+                account == null ||
+                rejectedToken.isEmpty() ||
+                !isActive(account)
+            ) {
+                throw e
+            }
+            val result = authToken.refreshAfterAuthenticationFailure(
+                account.toAndroidAccount(),
+                rejectedToken
+            )
+            if (result !is CheckTokenResult.Success || !isActive(account)) {
+                throw e
+            }
+            return request()
+        }
+    }
+
+    private fun isActive(account: AuthAccount): Boolean {
+        val activeAccount = preferences.account
+        return activeAccount?.name == account.name && activeAccount.type == account.type
+    }
+}

--- a/app/src/main/java/com/anod/appwatcher/accounts/AuthRecoveringDfeApi.kt
+++ b/app/src/main/java/com/anod/appwatcher/accounts/AuthRecoveringDfeApi.kt
@@ -56,7 +56,7 @@ internal class AuthRecoveringDfeApi(
 
     override suspend fun checkIn(): AndroidCheckinResponse = delegate.checkIn()
 
-    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity?): UploadDeviceConfigResponse =
+    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity): UploadDeviceConfigResponse =
         withAuthenticationRecovery { delegate.uploadDeviceConfig(identity) }
 
     private suspend fun <T> withAuthenticationRecovery(request: suspend () -> T): T {

--- a/app/src/main/java/com/anod/appwatcher/accounts/AuthTokenBlocking.kt
+++ b/app/src/main/java/com/anod/appwatcher/accounts/AuthTokenBlocking.kt
@@ -11,6 +11,8 @@ import java.io.IOException
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 class AuthTokenStartIntent(val intent: Intent) : RuntimeException("getAuthToken finished with intent: $intent")
@@ -27,77 +29,15 @@ sealed interface CheckTokenResult {
     class Error(val error: CheckTokenError) : CheckTokenResult
 }
 
-class AuthTokenBlocking(context: ApplicationContext) {
+internal interface AccountAuthTokenProvider {
+    fun getAuthToken(account: Account): String
+    fun invalidateAuthToken(token: String)
+}
 
-    companion object {
-        private const val AUTH_TOKEN_TYPE = "androidmarket"
-        const val ACCOUNT_TYPE = "com.google"
-        private val expiration = TimeUnit.MINUTES.toMillis(5L)
-    }
-
-    private val isFresh: Boolean
-        get() = token.isNotEmpty() && lastUpdated > 0 && (System.currentTimeMillis() - lastUpdated) < expiration
-
-    val tokenState = MutableStateFlow("")
-    val token: String
-        get() = tokenState.value
-
-    private val accountManager: AccountManager = AccountManager.get(context.actual)
-    private var lastUpdated = 0L
-
-    suspend fun checkToken(account: Account?): CheckTokenResult {
-        val account = account ?: return CheckTokenResult.Error(CheckTokenError.NoAccount)
-        if (isFresh) {
-            return CheckTokenResult.Success(invalidated = false)
-        }
-        return try {
-            return refreshToken(account)
-        } catch (e: AuthTokenStartIntent) {
-            CheckTokenResult.Error(CheckTokenError.RequiresInteraction(e.intent))
-        } catch (e: Exception) {
-            AppLog.e("onResume", e)
-            CheckTokenResult.Error(CheckTokenError.Unknown(e))
-        }
-    }
-
-    suspend fun refreshToken(account: Account): CheckTokenResult = withContext(Dispatchers.Main) {
-        val (token, invalidated) = retrieve(account)
-        tokenState.value = token
-        if (tokenState.value.isEmpty()) {
-            AppLog.e("Error retrieving token")
-            return@withContext CheckTokenResult.Error(CheckTokenError.NoToken)
-        }
-        lastUpdated = System.currentTimeMillis()
-        return@withContext CheckTokenResult.Success(invalidated = invalidated)
-    }
-
-    private suspend fun retrieve(acc: Account): Pair<String, Boolean> = withContext(Dispatchers.IO) {
-        val current = try {
-            getAuthToken(acc)
-        } catch (e: Exception) {
-            if (e is AuthTokenStartIntent) {
-                throw e
-            } else {
-                AppLog.e(e)
-                ""
-            }
-        }
-
-        if (current.isNotEmpty()) {
-            accountManager.invalidateAuthToken(ACCOUNT_TYPE, current)
-        }
-
-        val newToken = try {
-            getAuthToken(acc)
-        } catch (e: Exception) {
-            throw e
-        }
-        return@withContext Pair(newToken, current != newToken)
-    }
-
+private class AccountManagerAuthTokenProvider(private val accountManager: AccountManager) : AccountAuthTokenProvider {
     @Throws(AuthenticatorException::class, OperationCanceledException::class, IOException::class)
-    private fun getAuthToken(acc: Account): String {
-        val bundle = accountManager.getAuthToken(acc, AUTH_TOKEN_TYPE, null, false, null, null).result
+    override fun getAuthToken(account: Account): String {
+        val bundle = accountManager.getAuthToken(account, AuthTokenBlocking.AUTH_TOKEN_TYPE, null, false, null, null).result
         val token = bundle.getString(AccountManager.KEY_AUTHTOKEN) ?: ""
 
         if (token.isEmpty()) {
@@ -107,5 +47,145 @@ class AuthTokenBlocking(context: ApplicationContext) {
         }
 
         return token
+    }
+
+    override fun invalidateAuthToken(token: String) {
+        accountManager.invalidateAuthToken(AuthTokenBlocking.ACCOUNT_TYPE, token)
+    }
+}
+
+class AuthTokenBlocking private constructor(private val tokenProvider: AccountAuthTokenProvider) {
+    private data class TokenSession(val account: Account, val token: String)
+
+    companion object {
+        internal const val AUTH_TOKEN_TYPE = "androidmarket"
+        const val ACCOUNT_TYPE = "com.google"
+        private val expiration = TimeUnit.MINUTES.toMillis(5L)
+
+        internal fun create(tokenProvider: AccountAuthTokenProvider): AuthTokenBlocking =
+            AuthTokenBlocking(tokenProvider)
+    }
+
+    constructor(context: ApplicationContext)
+        : this(AccountManagerAuthTokenProvider(AccountManager.get(context.actual)))
+
+    val tokenState = MutableStateFlow("")
+    val token: String
+        get() = tokenSession?.token ?: ""
+
+    private val tokenMutex = Mutex()
+
+    @Volatile
+    private var tokenSession: TokenSession? = null
+    private var lastUpdated = 0L
+
+    suspend fun checkToken(account: Account?): CheckTokenResult {
+        val account = account ?: return CheckTokenResult.Error(CheckTokenError.NoAccount)
+        return try {
+            tokenMutex.withLock {
+                if (isFresh(account)) {
+                    CheckTokenResult.Success(invalidated = false)
+                } else {
+                    refreshTokenLocked(account, invalidate = false)
+                }
+            }
+        } catch (e: AuthTokenStartIntent) {
+            CheckTokenResult.Error(CheckTokenError.RequiresInteraction(e.intent))
+        } catch (e: Exception) {
+            AppLog.e("onResume", e)
+            CheckTokenResult.Error(CheckTokenError.Unknown(e))
+        }
+    }
+
+    suspend fun refreshToken(account: Account): CheckTokenResult = tokenMutex.withLock {
+        refreshTokenLocked(account, invalidate = false)
+    }
+
+    suspend fun invalidateAndRefreshToken(account: Account): CheckTokenResult = tokenMutex.withLock {
+        refreshTokenLocked(account, invalidate = true)
+    }
+
+    suspend fun refreshAfterAuthenticationFailure(
+        account: Account,
+        rejectedToken: String
+    ): CheckTokenResult = tokenMutex.withLock {
+        val session = tokenSession
+        if (
+            session != null &&
+            isSameAccount(session.account, account) &&
+            session.token.isNotEmpty() &&
+            session.token != rejectedToken
+        ) {
+            return@withLock CheckTokenResult.Success(invalidated = false)
+        }
+        updateToken(account, invalidateRejectedToken(account, rejectedToken))
+    }
+
+    private suspend fun refreshTokenLocked(account: Account, invalidate: Boolean): CheckTokenResult {
+        if (tokenSession != null && !isSameAccount(tokenSession?.account, account)) {
+            tokenSession = null
+            tokenState.value = ""
+            lastUpdated = 0L
+        }
+        return updateToken(account, retrieve(account, invalidate))
+    }
+
+    private fun updateToken(account: Account, result: Pair<String, Boolean>): CheckTokenResult {
+        val (token, invalidated) = result
+        tokenState.value = token
+        if (tokenState.value.isEmpty()) {
+            tokenSession = null
+            lastUpdated = 0L
+            AppLog.e("Error retrieving token")
+            return CheckTokenResult.Error(CheckTokenError.NoToken)
+        }
+        tokenSession = TokenSession(account, token)
+        lastUpdated = System.currentTimeMillis()
+        return CheckTokenResult.Success(invalidated = invalidated)
+    }
+
+    private fun isFresh(account: Account): Boolean {
+        val session = tokenSession ?: return false
+        return isSameAccount(session.account, account) &&
+            session.token.isNotEmpty() &&
+            lastUpdated > 0 &&
+            (System.currentTimeMillis() - lastUpdated) < expiration
+    }
+
+    private fun isSameAccount(first: Account?, second: Account): Boolean =
+        first?.name == second.name && first.type == second.type
+
+    internal fun tokenFor(account: AuthAccount?): String {
+        val session = tokenSession ?: return ""
+        return if (
+            account != null &&
+            session.account.name == account.name &&
+            session.account.type == account.type
+        ) {
+            session.token
+        } else {
+            ""
+        }
+    }
+
+    private suspend fun retrieve(acc: Account, invalidate: Boolean): Pair<String, Boolean> = withContext(Dispatchers.IO) {
+        val current = tokenProvider.getAuthToken(acc)
+        if (!invalidate || current.isEmpty()) {
+            return@withContext Pair(current, false)
+        }
+
+        tokenProvider.invalidateAuthToken(current)
+        tokenSession = null
+        tokenState.value = ""
+        lastUpdated = 0L
+        return@withContext Pair(tokenProvider.getAuthToken(acc), true)
+    }
+
+    private suspend fun invalidateRejectedToken(
+        account: Account,
+        rejectedToken: String
+    ): Pair<String, Boolean> = withContext(Dispatchers.IO) {
+        tokenProvider.invalidateAuthToken(rejectedToken)
+        Pair(tokenProvider.getAuthToken(account), true)
     }
 }

--- a/app/src/main/java/com/anod/appwatcher/accounts/DeviceRegistration.kt
+++ b/app/src/main/java/com/anod/appwatcher/accounts/DeviceRegistration.kt
@@ -1,0 +1,117 @@
+package com.anod.appwatcher.accounts
+
+import android.os.Build
+import com.anod.appwatcher.preferences.Preferences
+import finsky.api.DfeApi
+import finsky.api.DfeDeviceIdentity
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+sealed class DeviceRegistrationException(message: String) : IllegalStateException(message)
+
+class DeviceRegistrationPendingException :
+    DeviceRegistrationException("Previous device check-in did not return a reusable identity")
+
+class DeviceRegistrationRequiredException :
+    DeviceRegistrationException("Device registration requires explicit confirmation")
+
+internal class DeviceRegistration(
+    private val preferences: Preferences,
+    private val dfeApi: DfeApi,
+    private val sdkInt: Int = Build.VERSION.SDK_INT
+) {
+    companion object {
+        internal const val DEVICE_CONFIG_REVISION = 1
+    }
+
+    private val registrationMutex = Mutex()
+
+    suspend fun ensure(
+        account: AuthAccount,
+        allowCheckIn: Boolean = false
+    ): AuthAccount = registrationMutex.withLock {
+        val persistedAccount = preferences.account
+        check(
+            persistedAccount == null ||
+                (persistedAccount.name == account.name && persistedAccount.type == account.type)
+        ) {
+            "Active account changed during device registration"
+        }
+        val activeAccount = persistedAccount ?: account
+
+        if (sdkInt < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            return@withLock activeAccount
+        }
+
+        var registeredAccount = activeAccount
+        if (registeredAccount.gfsId.isEmpty()) {
+            if (!allowCheckIn) {
+                if (preferences.isDeviceRegistrationPending) {
+                    throw DeviceRegistrationPendingException()
+                }
+                throw DeviceRegistrationRequiredException()
+            }
+            registeredAccount = withContext(NonCancellable) {
+                if (!preferences.isDeviceRegistrationPending) {
+                    check(preferences.saveDeviceRegistrationPending(true)) {
+                        "Unable to persist device registration state"
+                    }
+                }
+                val response = dfeApi.checkIn()
+                check(response.androidId != 0L) { "Incorrect androidId" }
+                val checkedInAccount = registeredAccount.copy(
+                    gfsId = java.lang.Long.toHexString(response.androidId),
+                    gfsIdToken = response.deviceCheckinConsistencyToken.orEmpty(),
+                    deviceConfig = ""
+                )
+                check(
+                    preferences.saveAccount(
+                        checkedInAccount,
+                        deviceRegistrationPending = false,
+                        deviceConfigRevision = 0
+                    )
+                ) {
+                    "Unable to persist device identity"
+                }
+                checkedInAccount
+            }
+        }
+
+        if (
+            registeredAccount.deviceConfig.isNotEmpty() &&
+            preferences.deviceConfigRevision < DEVICE_CONFIG_REVISION
+        ) {
+            registeredAccount = registeredAccount.copy(deviceConfig = "")
+            check(
+                preferences.saveAccount(
+                    registeredAccount,
+                    deviceConfigRevision = 0
+                )
+            ) {
+                "Unable to invalidate legacy device config token"
+            }
+        }
+
+        if (registeredAccount.deviceConfig.isEmpty()) {
+            val identity = DfeDeviceIdentity(
+                deviceId = registeredAccount.gfsId,
+                deviceCheckinConsistencyToken = registeredAccount.gfsIdToken
+            )
+            val configToken = dfeApi.uploadDeviceConfig(identity).uploadDeviceConfigToken
+            check(configToken.isNotEmpty()) { "Device config token is empty" }
+            registeredAccount = registeredAccount.copy(deviceConfig = configToken)
+            check(
+                preferences.saveAccount(
+                    registeredAccount,
+                    deviceConfigRevision = DEVICE_CONFIG_REVISION
+                )
+            ) {
+                "Unable to persist device config token"
+            }
+        }
+
+        return@withLock registeredAccount
+    }
+}

--- a/app/src/main/java/com/anod/appwatcher/accounts/DeviceRegistration.kt
+++ b/app/src/main/java/com/anod/appwatcher/accounts/DeviceRegistration.kt
@@ -5,8 +5,6 @@ import com.anod.appwatcher.preferences.Preferences
 import finsky.api.DfeApi
 import finsky.api.DfeDeviceIdentity
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 sealed class DeviceRegistrationException(message: String) : IllegalStateException(message)
@@ -20,18 +18,16 @@ class DeviceRegistrationRequiredException :
 internal class DeviceRegistration(
     private val preferences: Preferences,
     private val dfeApi: DfeApi,
-    private val sdkInt: Int = Build.VERSION.SDK_INT
+    private val sdkInt: Int
 ) {
     companion object {
         internal const val DEVICE_CONFIG_REVISION = 1
     }
 
-    private val registrationMutex = Mutex()
-
     suspend fun ensure(
         account: AuthAccount,
-        allowCheckIn: Boolean = false
-    ): AuthAccount = registrationMutex.withLock {
+        allowCheckIn: Boolean
+    ): AuthAccount {
         val persistedAccount = preferences.account
         check(
             persistedAccount == null ||
@@ -42,7 +38,7 @@ internal class DeviceRegistration(
         val activeAccount = persistedAccount ?: account
 
         if (sdkInt < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            return@withLock activeAccount
+            return activeAccount
         }
 
         var registeredAccount = activeAccount
@@ -70,6 +66,7 @@ internal class DeviceRegistration(
                     preferences.saveAccount(
                         checkedInAccount,
                         deviceRegistrationPending = false,
+                        deviceRegistrationAuthorized = null,
                         deviceConfigRevision = 0
                     )
                 ) {
@@ -87,6 +84,8 @@ internal class DeviceRegistration(
             check(
                 preferences.saveAccount(
                     registeredAccount,
+                    deviceRegistrationPending = null,
+                    deviceRegistrationAuthorized = null,
                     deviceConfigRevision = 0
                 )
             ) {
@@ -97,7 +96,8 @@ internal class DeviceRegistration(
         if (registeredAccount.deviceConfig.isEmpty()) {
             val identity = DfeDeviceIdentity(
                 deviceId = registeredAccount.gfsId,
-                deviceCheckinConsistencyToken = registeredAccount.gfsIdToken
+                deviceCheckinConsistencyToken = registeredAccount.gfsIdToken,
+                deviceConfigToken = ""
             )
             val configToken = dfeApi.uploadDeviceConfig(identity).uploadDeviceConfigToken
             check(configToken.isNotEmpty()) { "Device config token is empty" }
@@ -105,6 +105,8 @@ internal class DeviceRegistration(
             check(
                 preferences.saveAccount(
                     registeredAccount,
+                    deviceRegistrationPending = null,
+                    deviceRegistrationAuthorized = null,
                     deviceConfigRevision = DEVICE_CONFIG_REVISION
                 )
             ) {
@@ -112,6 +114,6 @@ internal class DeviceRegistration(
             }
         }
 
-        return@withLock registeredAccount
+        return registeredAccount
     }
 }

--- a/app/src/main/java/com/anod/appwatcher/backup/BackupModule.kt
+++ b/app/src/main/java/com/anod/appwatcher/backup/BackupModule.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.anod.appwatcher.backup.gdrive.GDriveSync
 import com.anod.appwatcher.backup.gdrive.GDriveUpload
 import com.anod.appwatcher.preferences.Preferences
+import info.anodsplace.applog.AppLog
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
@@ -12,15 +13,14 @@ import org.koin.dsl.module
 class AppWatcherBackupAgent : BackupAgentHelper() {
     override fun onRestoreFinished() {
         super.onRestoreFinished()
-        check(
-            getSharedPreferences(
-                Preferences.DEVICE_PREFS_NAME,
-                Context.MODE_PRIVATE
-            ).edit()
-                .putBoolean(Preferences.RESTORED_FROM_BACKUP, true)
-                .commit()
-        ) {
-            "Unable to persist restore state"
+        val restoredStateSaved = getSharedPreferences(
+            Preferences.DEVICE_PREFS_NAME,
+            Context.MODE_PRIVATE
+        ).edit()
+            .putBoolean(Preferences.RESTORED_FROM_BACKUP, true)
+            .commit()
+        if (!restoredStateSaved) {
+            AppLog.e("Unable to persist restore state")
         }
     }
 }

--- a/app/src/main/java/com/anod/appwatcher/backup/BackupModule.kt
+++ b/app/src/main/java/com/anod/appwatcher/backup/BackupModule.kt
@@ -1,10 +1,29 @@
 package com.anod.appwatcher.backup
 
+import android.app.backup.BackupAgentHelper
+import android.content.Context
 import com.anod.appwatcher.backup.gdrive.GDriveSync
 import com.anod.appwatcher.backup.gdrive.GDriveUpload
+import com.anod.appwatcher.preferences.Preferences
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
+
+class AppWatcherBackupAgent : BackupAgentHelper() {
+    override fun onRestoreFinished() {
+        super.onRestoreFinished()
+        check(
+            getSharedPreferences(
+                Preferences.DEVICE_PREFS_NAME,
+                Context.MODE_PRIVATE
+            ).edit()
+                .putBoolean(Preferences.RESTORED_FROM_BACKUP, true)
+                .commit()
+        ) {
+            "Unable to persist restore state"
+        }
+    }
+}
 
 fun createBackupModule(): Module = module {
     factoryOf(::DbBackupManager)

--- a/app/src/main/java/com/anod/appwatcher/database/AppListTable.kt
+++ b/app/src/main/java/com/anod/appwatcher/database/AppListTable.kt
@@ -37,6 +37,14 @@ data class AppListRowSnapshot(
     val recentFlag: Boolean,
 )
 
+data class AppSyncUpdate(
+    val rowId: Long,
+    val expectedAppId: String,
+    val expectedPackageName: String,
+    val values: ContentValues,
+    val changelogValues: ContentValues
+)
+
 @Dao
 interface AppListTable {
 
@@ -275,6 +283,49 @@ interface AppListTable {
                     app.contentValues
                 )
             })
+        }
+
+        suspend fun applySyncUpdates(
+            updates: List<AppSyncUpdate>,
+            db: AppsDatabase
+        ): Set<Long> = withContext(Dispatchers.IO) {
+            val appliedRowIds = mutableSetOf<Long>()
+            db.withTransaction {
+                val writableDatabase = db.openHelper.writableDatabase
+                updates.forEach { update ->
+                    val updated = writableDatabase.update(
+                        TABLE,
+                        SQLiteDatabase.CONFLICT_REPLACE,
+                        update.values,
+                        "${BaseColumns._ID}=? AND " +
+                            "${Columns.APP_ID}=? AND " +
+                            "${Columns.PACKAGE_NAME}=? AND " +
+                            "${Columns.STATUS}!=?",
+                        arrayOf<Any>(
+                            update.rowId,
+                            update.expectedAppId,
+                            update.expectedPackageName,
+                            App.STATUS_DELETED
+                        )
+                    )
+                    if (updated == 0) {
+                        return@forEach
+                    }
+                    check(updated == 1) {
+                        "Multiple app rows matched synchronization update ${update.rowId}"
+                    }
+                    val changelogRowId = writableDatabase.insert(
+                        ChangelogTable.TABLE,
+                        SQLiteDatabase.CONFLICT_REPLACE,
+                        update.changelogValues
+                    )
+                    check(changelogRowId != -1L) {
+                        "Unable to persist changelog for app row ${update.rowId}"
+                    }
+                    appliedRowIds.add(update.rowId)
+                }
+            }
+            appliedRowIds
         }
 
         suspend fun delete(appId: String, db: AppsDatabase): Int {

--- a/app/src/main/java/com/anod/appwatcher/database/AppsDatabase.kt
+++ b/app/src/main/java/com/anod/appwatcher/database/AppsDatabase.kt
@@ -1,10 +1,8 @@
 package com.anod.appwatcher.database
 
-import android.content.ContentProviderOperation
-import android.content.ContentProviderResult
-import android.content.ContentResolver
 import android.content.ContentValues
-import android.net.Uri
+import android.database.sqlite.SQLiteDatabase
+import android.provider.BaseColumns
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
@@ -19,6 +17,14 @@ import com.anod.appwatcher.database.entities.Tag
 import info.anodsplace.applog.AppLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+
+data class AppSyncUpdate(
+    val rowId: Long,
+    val expectedAppId: String,
+    val expectedPackageName: String,
+    val values: ContentValues,
+    val changelogValues: ContentValues
+)
 
 /**
  * @author Alex Gavrishev
@@ -36,23 +42,39 @@ abstract class AppsDatabase : RoomDatabase() {
     abstract fun appTags(): AppTagsTable
     abstract fun schedules(): SchedulesTable
 
-    suspend fun applyBatchUpdates(contentResolver: ContentResolver, values: List<ContentValues>, uriMapper: (ContentValues) -> Uri): Array<ContentProviderResult> = withContext(Dispatchers.IO) {
-        val operations = values.map {
-            ContentProviderOperation.newUpdate(uriMapper(it)).withValues(it).build()
-        }
-
-        return@withContext withTransaction {
-            contentResolver.applyBatch(DbContentProvider.AUTHORITY, ArrayList(operations))
-        }
-    }
-
-    suspend fun applyBatchInsert(contentResolver: ContentResolver, values: List<ContentValues>, uriMapper: (ContentValues) -> Uri): Array<ContentProviderResult> = withContext(Dispatchers.IO) {
-        val operations = values.map {
-            ContentProviderOperation.newInsert(uriMapper(it)).withValues(it).build()
-        }
-
-        return@withContext withTransaction {
-            contentResolver.applyBatch(DbContentProvider.AUTHORITY, ArrayList(operations))
+    suspend fun applyAppSyncUpdates(
+        updates: List<AppSyncUpdate>
+    ) = withContext(Dispatchers.IO) {
+        withTransaction {
+            val db = openHelper.writableDatabase
+            updates.forEach { update ->
+                val updated = db.update(
+                    AppListTable.TABLE,
+                    SQLiteDatabase.CONFLICT_REPLACE,
+                    update.values,
+                    "${BaseColumns._ID}=? AND " +
+                        "${AppListTable.Columns.APP_ID}=? AND " +
+                        "${AppListTable.Columns.PACKAGE_NAME}=? AND " +
+                        "${AppListTable.Columns.STATUS}!=?",
+                    arrayOf<Any>(
+                        update.rowId,
+                        update.expectedAppId,
+                        update.expectedPackageName,
+                        App.STATUS_DELETED
+                    )
+                )
+                check(updated == 1) {
+                    "App row ${update.rowId} changed during synchronization"
+                }
+                val changelogRowId = db.insert(
+                    ChangelogTable.TABLE,
+                    SQLiteDatabase.CONFLICT_REPLACE,
+                    update.changelogValues
+                )
+                check(changelogRowId != -1L) {
+                    "Unable to persist changelog for app row ${update.rowId}"
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/anod/appwatcher/database/AppsDatabase.kt
+++ b/app/src/main/java/com/anod/appwatcher/database/AppsDatabase.kt
@@ -1,12 +1,8 @@
 package com.anod.appwatcher.database
 
-import android.content.ContentValues
-import android.database.sqlite.SQLiteDatabase
-import android.provider.BaseColumns
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
-import androidx.room.withTransaction
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.anod.appwatcher.BuildConfig
 import com.anod.appwatcher.database.entities.App
@@ -15,16 +11,6 @@ import com.anod.appwatcher.database.entities.AppTag
 import com.anod.appwatcher.database.entities.Schedule
 import com.anod.appwatcher.database.entities.Tag
 import info.anodsplace.applog.AppLog
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-
-data class AppSyncUpdate(
-    val rowId: Long,
-    val expectedAppId: String,
-    val expectedPackageName: String,
-    val values: ContentValues,
-    val changelogValues: ContentValues
-)
 
 /**
  * @author Alex Gavrishev
@@ -41,42 +27,6 @@ abstract class AppsDatabase : RoomDatabase() {
     abstract fun tags(): TagsTable
     abstract fun appTags(): AppTagsTable
     abstract fun schedules(): SchedulesTable
-
-    suspend fun applyAppSyncUpdates(
-        updates: List<AppSyncUpdate>
-    ) = withContext(Dispatchers.IO) {
-        withTransaction {
-            val db = openHelper.writableDatabase
-            updates.forEach { update ->
-                val updated = db.update(
-                    AppListTable.TABLE,
-                    SQLiteDatabase.CONFLICT_REPLACE,
-                    update.values,
-                    "${BaseColumns._ID}=? AND " +
-                        "${AppListTable.Columns.APP_ID}=? AND " +
-                        "${AppListTable.Columns.PACKAGE_NAME}=? AND " +
-                        "${AppListTable.Columns.STATUS}!=?",
-                    arrayOf<Any>(
-                        update.rowId,
-                        update.expectedAppId,
-                        update.expectedPackageName,
-                        App.STATUS_DELETED
-                    )
-                )
-                check(updated == 1) {
-                    "App row ${update.rowId} changed during synchronization"
-                }
-                val changelogRowId = db.insert(
-                    ChangelogTable.TABLE,
-                    SQLiteDatabase.CONFLICT_REPLACE,
-                    update.changelogValues
-                )
-                check(changelogRowId != -1L) {
-                    "Unable to persist changelog for app row ${update.rowId}"
-                }
-            }
-        }
-    }
 
     companion object {
         const val VERSION = 19

--- a/app/src/main/java/com/anod/appwatcher/preferences/Preferences.kt
+++ b/app/src/main/java/com/anod/appwatcher/preferences/Preferences.kt
@@ -4,14 +4,20 @@ import android.annotation.SuppressLint
 import android.app.UiModeManager
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.os.Build
 import com.anod.appwatcher.accounts.AuthAccount
+import com.anod.appwatcher.accounts.GfsIdResult
 import com.anod.appwatcher.model.Filters
+import info.anodsplace.applog.AppLog
 import info.anodsplace.graphics.AdaptiveIcon
 import info.anodsplace.notification.NotificationManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 data class SelectedTheme(val id: Int = Preferences.THEME_DEFAULT, val mode: Int = Preferences.THEME_MODE_SYSTEM) {
     val isBlack: Boolean = id == Preferences.THEME_BLACK
@@ -22,45 +28,123 @@ data class SelectedTheme(val id: Int = Preferences.THEME_DEFAULT, val mode: Int 
 class Preferences(context: Context, private val notificationManager: NotificationManager, private val appScope: CoroutineScope) : SharedPreferences.OnSharedPreferenceChangeListener {
     private val _changes = MutableSharedFlow<String>()
     private val preferences = context.getSharedPreferences(PREFS_NAME, 0)
+    private val devicePreferences = context.getSharedPreferences(DEVICE_PREFS_NAME, 0)
+
+    @Volatile
+    private var accountSnapshot: AuthAccount? = null
 
     val changes: Flow<String> = _changes
 
     init {
+        migrateDeviceRegistrationPreferences(
+            legacyPreferences = preferences,
+            devicePreferences = devicePreferences,
+            isSameDeviceUpgrade = isSameDeviceUpgrade(context),
+            wasRestored = devicePreferences.getBoolean(RESTORED_FROM_BACKUP, false)
+        )
+        accountSnapshot = readAccount()
         preferences.registerOnSharedPreferenceChangeListener(this)
+        devicePreferences.registerOnSharedPreferenceChangeListener(this)
     }
 
     var account: AuthAccount?
-        get() {
-            val name = preferences.getString(ACCOUNT_NAME, null) ?: return null
-            val type = preferences.getString(ACCOUNT_TYPE, null) ?: return null
-            val gfsId = preferences.getString(GFS_ID, "") ?: ""
-            val gfsToken = preferences.getString(GFS_TOKEN, "") ?: ""
-            val deviceConfig = preferences.getString(DEVICE_CONFIG, "") ?: ""
-            return AuthAccount(
-                name = name,
-                type = type,
-                gfsId = gfsId,
-                gfsIdToken = gfsToken,
-                deviceConfig = deviceConfig
-            )
-        }
+        get() = accountSnapshot
         set(value) {
-            val editor = preferences.edit()
-            if (value == null) {
-                editor.remove(ACCOUNT_NAME)
-                editor.remove(ACCOUNT_TYPE)
-                editor.remove(GFS_ID)
-                editor.remove(GFS_TOKEN)
-                editor.remove(DEVICE_CONFIG)
-            } else {
-                editor.putString(ACCOUNT_NAME, value.name)
-                editor.putString(ACCOUNT_TYPE, value.type)
-                editor.putString(GFS_ID, value.gfsId)
-                editor.putString(GFS_TOKEN, value.gfsIdToken)
-                editor.putString(DEVICE_CONFIG, value.deviceConfig)
-            }
-            editor.apply()
+            editAccount(
+                account = value,
+                deviceRegistrationPending = null,
+                deviceRegistrationAuthorized = null,
+                deviceConfigRevision = null
+            ).apply()
+            accountSnapshot = value
         }
+
+    val deviceIdentity: GfsIdResult
+        get() = accountSnapshot?.let { GfsIdResult(it.gfsId, it.gfsIdToken) } ?: GfsIdResult("", "")
+
+    val isDeviceRegistrationPending: Boolean
+        get() = devicePreferences.getBoolean(DEVICE_REGISTRATION_PENDING, false)
+
+    val isDeviceRegistrationAuthorized: Boolean
+        get() = devicePreferences.getBoolean(DEVICE_REGISTRATION_AUTHORIZED, false)
+
+    val deviceConfigRevision: Int
+        get() = devicePreferences.getInt(DEVICE_CONFIG_REVISION, 0)
+
+    val isDeviceRegistrationRequired: Boolean
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM &&
+            accountSnapshot?.gfsId.isNullOrEmpty()
+
+    suspend fun saveAccount(
+        account: AuthAccount?,
+        deviceRegistrationPending: Boolean? = null,
+        deviceRegistrationAuthorized: Boolean? = null,
+        deviceConfigRevision: Int? = null
+    ): Boolean = withContext(Dispatchers.IO) {
+        val committed = editAccount(
+            account,
+            deviceRegistrationPending,
+            deviceRegistrationAuthorized,
+            deviceConfigRevision
+        ).commit()
+        if (committed) {
+            accountSnapshot = account
+        }
+        committed
+    }
+
+    suspend fun saveDeviceRegistrationPending(pending: Boolean): Boolean = withContext(Dispatchers.IO) {
+        devicePreferences.edit().putBoolean(DEVICE_REGISTRATION_PENDING, pending).commit()
+    }
+
+    suspend fun saveDeviceRegistrationAuthorization(authorized: Boolean): Boolean = withContext(Dispatchers.IO) {
+        devicePreferences.edit().putBoolean(DEVICE_REGISTRATION_AUTHORIZED, authorized).commit()
+    }
+
+    private fun editAccount(
+        account: AuthAccount?,
+        deviceRegistrationPending: Boolean?,
+        deviceRegistrationAuthorized: Boolean?,
+        deviceConfigRevision: Int?
+    ): SharedPreferences.Editor = devicePreferences.edit().apply {
+        if (account == null) {
+            remove(ACCOUNT_NAME)
+            remove(ACCOUNT_TYPE)
+            remove(GFS_ID)
+            remove(GFS_TOKEN)
+            remove(DEVICE_CONFIG)
+            remove(DEVICE_REGISTRATION_PENDING)
+            remove(DEVICE_REGISTRATION_AUTHORIZED)
+            remove(DEVICE_CONFIG_REVISION)
+        } else {
+            putString(ACCOUNT_NAME, account.name)
+            putString(ACCOUNT_TYPE, account.type)
+            putString(GFS_ID, account.gfsId)
+            putString(GFS_TOKEN, account.gfsIdToken)
+            putString(DEVICE_CONFIG, account.deviceConfig)
+        }
+        if (deviceRegistrationPending != null) {
+            putBoolean(DEVICE_REGISTRATION_PENDING, deviceRegistrationPending)
+        }
+        if (deviceRegistrationAuthorized != null) {
+            putBoolean(DEVICE_REGISTRATION_AUTHORIZED, deviceRegistrationAuthorized)
+        }
+        if (deviceConfigRevision != null) {
+            putInt(DEVICE_CONFIG_REVISION, deviceConfigRevision)
+        }
+    }
+
+    private fun readAccount(): AuthAccount? {
+        val name = devicePreferences.getString(ACCOUNT_NAME, null) ?: return null
+        val type = devicePreferences.getString(ACCOUNT_TYPE, null) ?: return null
+        return AuthAccount(
+            name = name,
+            type = type,
+            gfsId = normalizeDeviceId(devicePreferences.getString(GFS_ID, "") ?: ""),
+            gfsIdToken = devicePreferences.getString(GFS_TOKEN, "") ?: "",
+            deviceConfig = devicePreferences.getString(DEVICE_CONFIG, "") ?: ""
+        )
+    }
 
     var notificationDisabledToastCount: Int
         get() = preferences.getInt("noti_disabled_toasts", -0)
@@ -199,6 +283,9 @@ class Preferences(context: Context, private val notificationManager: Notificatio
         private const val GFS_ID = "gfs_id"
         private const val GFS_TOKEN = "gfs_token"
         private const val DEVICE_CONFIG = "device_config"
+        private const val DEVICE_REGISTRATION_PENDING = "device_registration_pending"
+        private const val DEVICE_REGISTRATION_AUTHORIZED = "device_registration_authorized"
+        private const val DEVICE_CONFIG_REVISION = "device_config_revision"
         private const val ACCOUNT_NAME = "account_name"
         private const val ACCOUNT_TYPE = "account_type"
         private const val SORT_INDEX = "sort_index"
@@ -215,6 +302,8 @@ class Preferences(context: Context, private val notificationManager: Notificatio
         const val SORT_DATE_DESC = 3
 
         private const val PREFS_NAME = "WatcherPrefs"
+        internal const val DEVICE_PREFS_NAME = "DeviceRegistration"
+        internal const val RESTORED_FROM_BACKUP = "restored_from_backup"
         private const val DRIVE_SYNC = "drive_sync"
         private const val DRIVE_SYNC_TIME = "drive_sync_time"
         private const val AUTOSYNC = "autosync"
@@ -262,6 +351,124 @@ class Preferences(context: Context, private val notificationManager: Notificatio
             THEME_DEFAULT,
             THEME_BLACK,
         )
+
+        internal fun migrateDeviceRegistrationPreferences(
+            legacyPreferences: SharedPreferences,
+            devicePreferences: SharedPreferences,
+            isSameDeviceUpgrade: Boolean,
+            wasRestored: Boolean
+        ) {
+            if (
+                isSameDeviceUpgrade &&
+                !wasRestored &&
+                legacyPreferences.contains(ACCOUNT_NAME) &&
+                !devicePreferences.contains(ACCOUNT_NAME)
+            ) {
+                val editor = devicePreferences.edit()
+                copyString(legacyPreferences, editor, ACCOUNT_NAME)
+                copyString(legacyPreferences, editor, ACCOUNT_TYPE)
+                copyDeviceId(legacyPreferences, editor)
+                copyString(legacyPreferences, editor, GFS_TOKEN)
+                copyString(legacyPreferences, editor, DEVICE_CONFIG)
+                copyBoolean(legacyPreferences, editor, DEVICE_REGISTRATION_PENDING)
+                copyBoolean(legacyPreferences, editor, DEVICE_REGISTRATION_AUTHORIZED)
+                copyInt(legacyPreferences, editor, DEVICE_CONFIG_REVISION)
+                if (!editor.commit()) {
+                    AppLog.e("Unable to migrate device registration preferences")
+                    return
+                }
+            }
+
+            val removed = legacyPreferences.edit()
+                .remove(ACCOUNT_NAME)
+                .remove(ACCOUNT_TYPE)
+                .remove(GFS_ID)
+                .remove(GFS_TOKEN)
+                .remove(DEVICE_CONFIG)
+                .remove(DEVICE_REGISTRATION_PENDING)
+                .remove(DEVICE_REGISTRATION_AUTHORIZED)
+                .remove(DEVICE_CONFIG_REVISION)
+                .commit()
+            if (!removed) {
+                AppLog.e("Unable to remove legacy device registration preferences")
+                return
+            }
+            if (wasRestored && !devicePreferences.edit().remove(RESTORED_FROM_BACKUP).commit()) {
+                AppLog.e("Unable to clear restored device registration state")
+            }
+        }
+
+        internal fun normalizeDeviceId(deviceId: String): String {
+            val normalized = deviceId.lowercase()
+            if (normalized.matches(Regex("[0-9a-f]{1,16}"))) {
+                return normalized.takeIf { id -> id.any { it != '0' } }.orEmpty()
+            }
+            if (normalized.matches(Regex("-[0-9a-f]{1,16}"))) {
+                val signedId = normalized.toLongOrNull(16) ?: return ""
+                return java.lang.Long.toHexString(signedId).takeUnless { it == "0" }.orEmpty()
+            }
+            return ""
+        }
+
+        private fun copyString(
+            source: SharedPreferences,
+            destination: SharedPreferences.Editor,
+            key: String
+        ) {
+            if (source.contains(key)) {
+                destination.putString(key, source.getString(key, null))
+            }
+        }
+
+        private fun copyBoolean(
+            source: SharedPreferences,
+            destination: SharedPreferences.Editor,
+            key: String
+        ) {
+            if (source.contains(key)) {
+                destination.putBoolean(key, source.getBoolean(key, false))
+            }
+        }
+
+        private fun copyDeviceId(
+            source: SharedPreferences,
+            destination: SharedPreferences.Editor
+        ) {
+            if (source.contains(GFS_ID)) {
+                destination.putString(
+                    GFS_ID,
+                    normalizeDeviceId(source.getString(GFS_ID, null).orEmpty())
+                )
+            }
+        }
+
+        private fun copyInt(
+            source: SharedPreferences,
+            destination: SharedPreferences.Editor,
+            key: String
+        ) {
+            if (source.contains(key)) {
+                destination.putInt(key, source.getInt(key, 0))
+            }
+        }
+
+        private fun isSameDeviceUpgrade(context: Context): Boolean {
+            val packageInfo = try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    context.packageManager.getPackageInfo(
+                        context.packageName,
+                        PackageManager.PackageInfoFlags.of(0)
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    context.packageManager.getPackageInfo(context.packageName, 0)
+                }
+            } catch (error: PackageManager.NameNotFoundException) {
+                AppLog.e(error)
+                return false
+            }
+            return packageInfo.firstInstallTime < packageInfo.lastUpdateTime
+        }
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {

--- a/app/src/main/java/com/anod/appwatcher/preferences/Preferences.kt
+++ b/app/src/main/java/com/anod/appwatcher/preferences/Preferences.kt
@@ -77,9 +77,9 @@ class Preferences(context: Context, private val notificationManager: Notificatio
 
     suspend fun saveAccount(
         account: AuthAccount?,
-        deviceRegistrationPending: Boolean? = null,
-        deviceRegistrationAuthorized: Boolean? = null,
-        deviceConfigRevision: Int? = null
+        deviceRegistrationPending: Boolean?,
+        deviceRegistrationAuthorized: Boolean?,
+        deviceConfigRevision: Int?
     ): Boolean = withContext(Dispatchers.IO) {
         val committed = editAccount(
             account,

--- a/app/src/main/java/com/anod/appwatcher/search/SearchResultsScreen.kt
+++ b/app/src/main/java/com/anod/appwatcher/search/SearchResultsScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavKey
 import androidx.paging.LoadState
@@ -86,6 +88,9 @@ fun SearchResultsScreenScene(
     val screenState by viewModel.viewStates.collectAsState(initial = viewModel.viewState)
     val accountSelectionRequest = rememberLauncherForActivityResult(AccountSelectionRequest()) {
         viewModel.handleEvent(SearchViewEvent.SetAccount(it))
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.handleEvent(SearchViewEvent.OnResume)
     }
     AppTheme(
         theme = prefs.selectedTheme,
@@ -156,7 +161,7 @@ fun SearchResultsScreen(
                 is SearchStatus.NoNetwork -> RetryButton(onRetryClick = { onEvent(SearchViewEvent.OnSearchEnter(searchStatus.query)) })
                 is SearchStatus.NoResults -> EmptyResult(query = searchStatus.query)
                 is SearchStatus.SearchList -> {
-                    val pagingData = remember(searchStatus.query) { pagingDataFlow() }
+                    val pagingData = remember(searchStatus.query, searchStatus.generation) { pagingDataFlow() }
                     val items = pagingData.collectAsLazyPagingItems()
                     val isError = items.loadState.source.refresh is LoadState.Error
                     val isEmpty = (items.loadState.source.refresh is LoadState.NotLoading && items.itemCount < 1)

--- a/app/src/main/java/com/anod/appwatcher/search/SearchViewModel.kt
+++ b/app/src/main/java/com/anod/appwatcher/search/SearchViewModel.kt
@@ -137,7 +137,11 @@ class SearchViewModel(initialState: SearchViewState) : BaseFlowViewModel<SearchV
                 if (event.result is AccountSelectionResult.Error) {
                     onAccountSelectError(event.result.errorMessage)
                 } else if (event.result is AccountSelectionResult.Success) {
-                    onAccountSelected(event.result.account, userInitiated = true)
+                    onAccountSelected(
+                        account = event.result.account,
+                        userInitiated = true,
+                        resumingInteractiveAuth = false
+                    )
                 }
             }
 
@@ -293,7 +297,7 @@ class SearchViewModel(initialState: SearchViewState) : BaseFlowViewModel<SearchV
     private fun onAccountSelected(
         account: Account,
         userInitiated: Boolean,
-        resumingInteractiveAuth: Boolean = false
+        resumingInteractiveAuth: Boolean
     ) {
         if (accountInitializationJob?.isActive == true) {
             return

--- a/app/src/main/java/com/anod/appwatcher/search/SearchViewModel.kt
+++ b/app/src/main/java/com/anod/appwatcher/search/SearchViewModel.kt
@@ -18,11 +18,13 @@ import androidx.paging.filter
 import androidx.paging.map
 import com.anod.appwatcher.R
 import com.anod.appwatcher.accounts.AccountSelectionResult
+import com.anod.appwatcher.accounts.AccountSessionBusyException
 import com.anod.appwatcher.accounts.AuthAccountInitializer
 import com.anod.appwatcher.accounts.AuthTokenBlocking
 import com.anod.appwatcher.accounts.AuthTokenStartIntent
 import com.anod.appwatcher.accounts.CheckTokenError
 import com.anod.appwatcher.accounts.CheckTokenResult
+import com.anod.appwatcher.accounts.DeviceRegistrationException
 import com.anod.appwatcher.accounts.showAccountSelectionAction
 import com.anod.appwatcher.accounts.toAndroidAccount
 import com.anod.appwatcher.database.AppsDatabase
@@ -42,7 +44,10 @@ import info.anodsplace.framework.content.ScreenCommonAction
 import info.anodsplace.framework.content.showToastAction
 import info.anodsplace.framework.content.startActivityAction
 import info.anodsplace.playstore.AppDetailsFilter
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -58,11 +63,12 @@ sealed interface SearchStatus {
     data class NoResults(val query: String) : SearchStatus
     data class NoNetwork(val query: String) : SearchStatus
     data class Error(val query: String) : SearchStatus
-    data class SearchList(val query: String) : SearchStatus
+    data class SearchList(val query: String, val generation: Int) : SearchStatus
 }
 
 sealed interface SearchViewEvent {
     data object NoAccount : SearchViewEvent
+    data object OnResume : SearchViewEvent
     data object OnBackPressed : SearchViewEvent
     class SearchQueryChange(val query: String) : SearchViewEvent
     class OnSearchEnter(val query: String) : SearchViewEvent
@@ -100,16 +106,19 @@ class SearchViewModel(initialState: SearchViewState) : BaseFlowViewModel<SearchV
     private val dfeApi: DfeApi by inject()
 
     private var searchJob: Job? = null
+    private var accountInitializationJob: Job? = null
+    private var pendingAccountInitialization: Account? = null
 
     override fun onCleared() {
         searchJob?.cancel()
+        accountInitializationJob?.cancel()
     }
 
     init {
         viewState = initialState.copy(
             searchStatus = if (initialState.searchQuery.isNotEmpty() && initialState.initiateSearch) SearchStatus.Loading else SearchStatus.NoResults(query = ""),
         )
-        if (prefs.account == null) {
+        if (prefs.account == null || prefs.isDeviceRegistrationRequired) {
             handleEvent(SearchViewEvent.NoAccount)
         }
 
@@ -121,13 +130,14 @@ class SearchViewModel(initialState: SearchViewState) : BaseFlowViewModel<SearchV
     override fun handleEvent(event: SearchViewEvent) {
         when (event) {
             SearchViewEvent.NoAccount -> emitAction(showAccountSelectionAction(prefs.account?.toAndroidAccount()))
+            SearchViewEvent.OnResume -> resumeAccountInitialization()
             is SearchViewEvent.SearchQueryChange -> viewState = viewState.copy(searchQuery = event.query)
             is SearchViewEvent.OnSearchEnter -> onSearchRequest(event.query)
             is SearchViewEvent.SetAccount -> {
                 if (event.result is AccountSelectionResult.Error) {
                     onAccountSelectError(event.result.errorMessage)
                 } else if (event.result is AccountSelectionResult.Success) {
-                    onAccountSelected(event.result.account)
+                    onAccountSelected(event.result.account, userInitiated = true)
                 }
             }
 
@@ -212,24 +222,22 @@ class SearchViewModel(initialState: SearchViewState) : BaseFlowViewModel<SearchV
                         )
                     )
                 } else {
-                    resetPager()
-                    emit(SearchStatus.SearchList(query = query))
+                    emit(SearchStatus.SearchList(query = query, generation = resetPager()))
                 }
             } catch (_: Exception) {
                 if (!networkConnection.isNetworkAvailable) {
                     emit(SearchStatus.NoNetwork(query = query))
                 } else {
-                    resetPager()
-                    emit(SearchStatus.SearchList(query = query))
+                    emit(SearchStatus.SearchList(query = query, generation = resetPager()))
                 }
             }
         } else {
-            resetPager()
-            emit(SearchStatus.SearchList(query = query))
+            emit(SearchStatus.SearchList(query = query, generation = resetPager()))
         }
     }
 
     private var _pagingData: Flow<PagingData<ListItem>>? = null
+    private var pagerGeneration = 0
     val pagingData: Flow<PagingData<ListItem>>
         get() {
             if (_pagingData == null) {
@@ -238,9 +246,11 @@ class SearchViewModel(initialState: SearchViewState) : BaseFlowViewModel<SearchV
             return _pagingData!!
         }
 
-    private fun resetPager() {
+    private fun resetPager(): Int {
         // Trigger new pager creation
         _pagingData = null
+        pagerGeneration++
+        return pagerGeneration
     }
 
     private fun createPager() = Pager(
@@ -265,13 +275,66 @@ class SearchViewModel(initialState: SearchViewState) : BaseFlowViewModel<SearchV
             flow = database.apps().observePackages().distinctUntilChanged()
         ) { pageData, watchingPackages -> pageData.updateRowId(watchingPackages) }
 
-    private fun onAccountSelected(account: Account) {
-        viewModelScope.launch {
+    private fun resumeAccountInitialization() {
+        if (accountInitializationJob?.isActive == true) {
+            return
+        }
+        val account = pendingAccountInitialization
+            ?: if (prefs.isDeviceRegistrationAuthorized) prefs.account?.toAndroidAccount() else null
+        if (account != null) {
+            onAccountSelected(
+                account,
+                userInitiated = false,
+                resumingInteractiveAuth = true
+            )
+        }
+    }
+
+    private fun onAccountSelected(
+        account: Account,
+        userInitiated: Boolean,
+        resumingInteractiveAuth: Boolean = false
+    ) {
+        if (accountInitializationJob?.isActive == true) {
+            return
+        }
+        accountInitializationJob = viewModelScope.launch {
             try {
-                accountInitializer.initialize(account)
+                accountInitializer.initialize(account, userInitiated)
+                pendingAccountInitialization = null
+                viewState = viewState.copy(authenticated = true)
+                if (viewState.searchQuery.isNotEmpty()) {
+                    onSearchRequest(viewState.searchQuery)
+                }
             } catch (e: AuthTokenStartIntent) {
-                emitAction(startActivityAction(intent = e.intent)) //  TODO: finish = true
+                currentCoroutineContext().ensureActive()
+                if (resumingInteractiveAuth) {
+                    pendingAccountInitialization = null
+                    accountInitializer.clearDeviceRegistrationAuthorization()
+                    onAccountSelectError("")
+                } else {
+                    pendingAccountInitialization = account
+                    emitAction(startActivityAction(intent = e.intent)) //  TODO: finish = true
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: DeviceRegistrationException) {
+                currentCoroutineContext().ensureActive()
+                pendingAccountInitialization = null
+                emitAction(showToastAction(
+                    text = context.getString(R.string.failed_gain_access),
+                    length = Toast.LENGTH_LONG
+                ))
+                emitAction(showAccountSelectionAction(prefs.account?.toAndroidAccount()))
+            } catch (_: AccountSessionBusyException) {
+                currentCoroutineContext().ensureActive()
+                emitAction(showToastAction(
+                    text = context.getString(R.string.sync_in_progress_retry),
+                    length = Toast.LENGTH_LONG
+                ))
             } catch (e: Exception) {
+                currentCoroutineContext().ensureActive()
+                pendingAccountInitialization = null
                 if (networkConnection.isNetworkAvailable) {
                     emitAction(showToastAction(text = context.getString(R.string.failed_gain_access), length = Toast.LENGTH_LONG))
                     emitAction(ScreenCommonAction.NavigateBack)

--- a/app/src/main/java/com/anod/appwatcher/sync/UpdateCheck.kt
+++ b/app/src/main/java/com/anod/appwatcher/sync/UpdateCheck.kt
@@ -1,23 +1,21 @@
 package com.anod.appwatcher.sync
 
-import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.RemoteException
 import android.provider.BaseColumns
 import android.text.format.DateUtils
-import androidx.core.content.contentValuesOf
 import androidx.work.Data
 import com.anod.appwatcher.accounts.AuthAccountInitializer
 import com.anod.appwatcher.accounts.AuthTokenStartIntent
+import com.anod.appwatcher.accounts.AuthTokenUnavailableException
 import com.anod.appwatcher.backup.gdrive.GDriveSilentSignIn
 import com.anod.appwatcher.backup.gdrive.GDriveSync
 import com.anod.appwatcher.database.AppListTable
+import com.anod.appwatcher.database.AppSyncUpdate
 import com.anod.appwatcher.database.AppsDatabase
-import com.anod.appwatcher.database.ChangelogTable
 import com.anod.appwatcher.database.Cleanup
-import com.anod.appwatcher.database.DbContentProvider
 import com.anod.appwatcher.database.SchedulesTable
 import com.anod.appwatcher.database.contentValues
 import com.anod.appwatcher.database.entities.App
@@ -31,14 +29,20 @@ import com.anod.appwatcher.utils.date.UploadDateParserCache
 import com.anod.appwatcher.utils.extractUploadDate
 import finsky.api.BulkDocId
 import finsky.api.DfeApi
+import finsky.api.DfeServerError
 import finsky.api.Document
 import finsky.api.filterDocuments
 import info.anodsplace.applog.AppLog
 import info.anodsplace.framework.content.InstalledApps
 import info.anodsplace.framework.net.NetworkConnectivity
 import info.anodsplace.playstore.AppDetailsFilter
+import java.io.IOException
 import java.util.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.koin.core.Koin
 import org.koin.core.parameter.parametersOf
@@ -62,10 +66,22 @@ class UpdateCheck(
 
     class SyncResult(val success: Boolean, val updates: List<UpdatedApp>, val checked: Int, val unavailable: Int)
 
+    private data class PendingAppUpdate(
+        val rowId: Long,
+        val expectedAppId: String,
+        val expectedPackageName: String,
+        val values: ContentValues,
+        val changelog: ContentValues,
+        val updatedApp: UpdatedApp?
+    )
+
     companion object {
         private const val ONE_SEC_IN_MILLIS = 1000
         private const val BULK_SIZE = 20
+        private const val MAX_CHUNK_ATTEMPTS = 3
+        private const val CHUNK_RETRY_DELAY_MILLIS = 250L
         internal const val EXTRAS_MANUAL = "manual"
+        private val syncMutex = Mutex()
 
         const val SYNC_STOP = "com.anod.appwatcher.sync.start"
         const val SYNC_PROGRESS = "com.anod.appwatcher.sync.progress"
@@ -74,7 +90,11 @@ class UpdateCheck(
 
     private val installedAppsProvider = InstalledApps.PackageManager(packageManager)
 
-    suspend fun perform(extras: Data): Int = withContext(Dispatchers.Default) {
+    suspend fun perform(extras: Data): Int = syncMutex.withLock {
+        performSerialized(extras)
+    }
+
+    private suspend fun performSerialized(extras: Data): Int = withContext(Dispatchers.Default) {
         val manualSync = extras.getBoolean(EXTRAS_MANUAL, false)
         AppLog.i("Perform ${if (manualSync) "manual" else "scheduled"} sync", "UpdateCheck")
         val schedule = Schedule(manualSync)
@@ -103,34 +123,45 @@ class UpdateCheck(
 
         AppLog.i("Perform synchronization", "UpdateCheck")
 
-        val refreshed = refreshAuthToken()
-        if (!refreshed) {
-            SchedulesTable.Queries.save(schedule.finish(Schedule.STATUS_FAILED_NO_TOKEN), database)
-            AppLog.e("Cannot receive access token")
-            return@withContext -1
-        }
-
-        // Broadcast progress intent
-        val startIntent = Intent(SYNC_PROGRESS).apply {
-            `package` = context.actual.packageName
-        }
-        context.sendBroadcast(startIntent)
-
         val lastUpdatesViewed = preferences.isLastUpdatesViewed
-        AppLog.d("Last update viewed: $lastUpdatesViewed")
-        SchedulesTable.Queries.save(schedule, database)
-
         val syncResult = try {
-            doSync(lastUpdatesViewed)
+            authAccount.withRefreshedAccount {
+                val startIntent = Intent(SYNC_PROGRESS).apply {
+                    `package` = context.actual.packageName
+                }
+                context.sendBroadcast(startIntent)
+
+                AppLog.d("Last update viewed: $lastUpdatesViewed")
+                SchedulesTable.Queries.save(schedule, database)
+
+                try {
+                    doSync(lastUpdatesViewed)
+                } catch (e: AuthTokenStartIntent) {
+                    throw e
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    AppLog.e("Error during synchronization ${e.message}", e)
+                    SyncResult(false, listOf(), 0, 0)
+                }
+            }
+        } catch (e: AuthTokenStartIntent) {
+            AppLog.e("AuthToken: require interactive sing in")
+            return@withContext finishFailedSync(schedule, Schedule.STATUS_FAILED_NO_TOKEN, manualSync)
+        } catch (e: AuthTokenUnavailableException) {
+            AppLog.e("Cannot receive access token", e)
+            return@withContext finishFailedSync(schedule, Schedule.STATUS_FAILED_NO_TOKEN, manualSync)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            AppLog.e("Error during synchronization ${e.message}", e)
-            SyncResult(false, listOf(), 0, 0)
+            AppLog.e("Play Store session refresh or sync setup failed: ${e.message}", e)
+            return@withContext finishFailedSync(schedule, Schedule.STATUS_FAILED, manualSync)
         }
 
         if (syncResult.success) {
             SchedulesTable.Queries.save(schedule.finish(Schedule.STATUS_SUCCESS, syncResult.checked, syncResult.updates.size, syncResult.unavailable), database)
         } else {
-            SchedulesTable.Queries.save(schedule.finish(Schedule.STATUS_FAILED), database)
+            return@withContext finishFailedSync(schedule, Schedule.STATUS_FAILED, manualSync)
         }
 
         val updatedApps: List<UpdatedApp> = syncResult.updates
@@ -152,16 +183,7 @@ class UpdateCheck(
 
         notifyIfNeeded(manualSync, updatedApps, schedule)
 
-        if (!manualSync) {
-            if (preferences.isDriveSyncEnabled) {
-                AppLog.d("DriveSyncEnabled = true")
-                performGDriveSync(preferences, now)
-            } else {
-                AppLog.d("DriveSyncEnabled = false, skipping...")
-            }
-
-            Cleanup(preferences, database).performIfNeeded(now)
-        }
+        performMaintenance(manualSync, now)
 
         AppLog.d("Finish::perform()")
         return@withContext updatedApps.size
@@ -177,49 +199,71 @@ class UpdateCheck(
             return SyncResult(true, listOf(), 0, 0)
         }
 
-        val updatedApps = mutableListOf<UpdatedApp>()
+        val localAppChunks = try {
+            apps.chunked(BULK_SIZE) { list ->
+                list.associateBy { it.app.packageName }
+            }
+        } finally {
+            apps.close()
+        }
         var unavailable = 0
-        apps.chunked(BULK_SIZE) { list ->
-            list.associateBy { it.app.packageName }
-        }.forEach { localApps ->
+        val fetchedChunks = fetchAllChunks(
+            chunks = localAppChunks,
+            maxAttempts = MAX_CHUNK_ATTEMPTS,
+            initialRetryDelayMillis = CHUNK_RETRY_DELAY_MILLIS
+        ) { localApps ->
             val docIds = localApps.map { BulkDocId(it.key, it.value.app.versionNumber) }
             val dfeApi = koin.get<DfeApi>()
             AppLog.d("Sending chunk... $docIds")
-            val documents = try {
-                dfeApi.details(docIds, includeDetails = true).filterDocuments(AppDetailsFilter.hasAppDetails)
-            } catch (e: Exception) {
-                AppLog.e("Fetching of bulk updates failed ${e.message ?: ""}", "UpdateCheck")
-                emptyList()
-            }
+            val documents = dfeApi.details(docIds, includeDetails = true)
+                .filterDocuments(AppDetailsFilter.hasAppDetails)
             unavailable += (docIds.size - documents.size)
             AppLog.i("Sent ${docIds.size}, received ${documents.size}", "UpdateCheck")
-            updateApps(documents, localApps, updatedApps, lastUpdatesViewed, context.contentResolver, database)
+            documents
         }
+        val pendingUpdates = fetchedChunks.flatMap { (localApps, documents) ->
+            prepareAppUpdates(documents, localApps, lastUpdatesViewed)
+        }
+        val updatedApps = applyAppUpdates(pendingUpdates, database)
 
-        apps.close()
-        AppLog.i("Sync finished for ${apps.count} apps", "UpdateCheck")
-        return SyncResult(true, updatedApps, apps.count, unavailable)
+        val checked = localAppChunks.sumOf { it.size }
+        AppLog.i("Sync finished for $checked apps", "UpdateCheck")
+        return SyncResult(true, updatedApps, checked, unavailable)
     }
 
-    private suspend fun updateApps(
+    private suspend fun finishFailedSync(
+        schedule: Schedule,
+        status: Int,
+        manualSync: Boolean
+    ): Int {
+        SchedulesTable.Queries.save(schedule.finish(status), database)
+        performMaintenance(manualSync, System.currentTimeMillis())
+        return -1
+    }
+
+    private suspend fun performMaintenance(manualSync: Boolean, now: Long) {
+        if (manualSync) {
+            return
+        }
+        if (preferences.isDriveSyncEnabled) {
+            AppLog.d("DriveSyncEnabled = true")
+            performGDriveSync(preferences, now)
+        } else {
+            AppLog.d("DriveSyncEnabled = false, skipping...")
+        }
+        Cleanup(preferences, database).performIfNeeded(now)
+    }
+
+    private fun prepareAppUpdates(
         documents: List<Document>,
         localApps: Map<String, AppListItem>,
-        updatedApps: MutableList<UpdatedApp>,
-        lastUpdatesViewed: Boolean,
-        contentResolver: ContentResolver,
-        db: AppsDatabase
-    ) {
-        val fetched = mutableMapOf<String, Boolean>()
-        val batch = mutableListOf<ContentValues>()
-        val changelog = mutableListOf<ContentValues>()
+        lastUpdatesViewed: Boolean
+    ): List<PendingAppUpdate> {
+        val pendingUpdates = mutableListOf<PendingAppUpdate>()
         for (marketApp in documents) {
             val docId = marketApp.docId
             localApps[docId]?.let { localItem ->
-                fetched[docId] = true
                 val (values, updatedApp) = updateApp(marketApp, localItem, lastUpdatesViewed)
-                if (values.size() > 0) {
-                    batch.add(values)
-                }
                 val isNewVersion = marketApp.appDetails.versionCode > localItem.app.versionNumber
                 val recentChanges = marketApp.appDetails.recentChangesHtml?.trim() ?: ""
                 val noNewDetails = if (isNewVersion) {
@@ -227,65 +271,66 @@ class UpdateCheck(
                 } else {
                     localItem.noNewDetails
                 }
-                changelog.add(AppChange(
-                    docId,
-                    marketApp.appDetails.versionCode,
-                    marketApp.appDetails.versionString,
-                    recentChanges,
-                    marketApp.appDetails.uploadDate,
-                    noNewDetails).contentValues)
-                if (updatedApp != null) {
-                    updatedApps.add(updatedApp.copy(noNewDetails = noNewDetails))
+                if (values.size() > 0) {
+                    pendingUpdates.add(
+                        PendingAppUpdate(
+                            rowId = localItem.app.rowId.toLong(),
+                            expectedAppId = localItem.app.appId,
+                            expectedPackageName = localItem.app.packageName,
+                            values = values,
+                            changelog = AppChange(
+                                docId,
+                                marketApp.appDetails.versionCode,
+                                marketApp.appDetails.versionString,
+                                recentChanges,
+                                marketApp.appDetails.uploadDate,
+                                noNewDetails
+                            ).contentValues,
+                            updatedApp = updatedApp?.copy(noNewDetails = noNewDetails)
+                        )
+                    )
                 }
             }
         }
+        return pendingUpdates
+    }
 
-        if (batch.isNotEmpty()) {
-            db.applyBatchUpdates(contentResolver, batch) {
-                val rowId = it.getAsString(BaseColumns._ID)
-                DbContentProvider.appsUri.buildUpon().appendPath(rowId).build()
-            }
+    private suspend fun applyAppUpdates(
+        pendingUpdates: List<PendingAppUpdate>,
+        db: AppsDatabase
+    ): List<UpdatedApp> {
+        if (pendingUpdates.isEmpty()) {
+            return emptyList()
         }
 
-        if (changelog.isNotEmpty()) {
-            db.applyBatchInsert(contentResolver, changelog) {
-                DbContentProvider.changelogUri
-                    .buildUpon()
-                    .appendPath("apps")
-                    .appendPath(it.getAsString(ChangelogTable.Columns.APP_ID))
-                    .appendPath("v")
-                    .appendPath(it.getAsString(ChangelogTable.Columns.VERSION_CODE))
-                    .build()
+        db.applyAppSyncUpdates(
+            pendingUpdates.map { update ->
+                AppSyncUpdate(
+                    rowId = update.rowId,
+                    expectedAppId = update.expectedAppId,
+                    expectedPackageName = update.expectedPackageName,
+                    values = update.values,
+                    changelogValues = update.changelog
+                )
             }
-        }
-
-        // Reset not fetched app statuses
-        if (lastUpdatesViewed && fetched.size < localApps.size) {
-            val statusBatch = mutableListOf<ContentValues>()
-            localApps.values.forEach {
-                val app = it.app
-                if (fetched[app.appId] == null) {
-                    if (app.status == App.STATUS_UPDATED) {
-                        AppLog.d("Set not fetched app as viewed")
-                        statusBatch.add(contentValuesOf(
-                            BaseColumns._ID to app.rowId,
-                            AppListTable.Columns.STATUS to App.STATUS_NORMAL
-                        ))
-                    }
-                }
-            }
-            if (statusBatch.isNotEmpty()) {
-                db.applyBatchUpdates(contentResolver, statusBatch) {
-                    val rowId = it.getAsString(BaseColumns._ID)
-                    DbContentProvider.appsUri.buildUpon().appendPath(rowId).build()
-                }
-            }
-        }
+        )
+        return pendingUpdates.mapNotNull { it.updatedApp }
     }
 
     private fun updateApp(marketDoc: Document, localItem: AppListItem, lastUpdatesViewed: Boolean): Pair<ContentValues, UpdatedApp?> {
         val appDetails = marketDoc.appDetails
         val localApp = localItem.app
+
+        val values = ContentValues()
+        if (reconcileVersionRollback(appDetails.versionCode, localApp, values)) {
+            AppLog.w(
+                "Play Store version rolled back for ${localApp.packageName}: " +
+                    "${localApp.versionNumber} -> ${appDetails.versionCode}",
+                "UpdateCheck"
+            )
+            updateLocalApp(marketDoc, localApp, values)
+            return Pair(values, null)
+        }
 
         if (appDetails.versionCode > localApp.versionNumber) {
             AppLog.d("New version found [" + appDetails.versionCode + "]")
@@ -301,7 +346,6 @@ class UpdateCheck(
             return Pair(newApp.contentValues, UpdatedApp(newApp, recentChanges, installedInfo.versionCode, true))
         }
 
-        val values = ContentValues()
         var updatedApp: UpdatedApp? = null
         // Mark updated app as normal
         if (localApp.status == App.STATUS_UPDATED && lastUpdatesViewed) {
@@ -368,17 +412,6 @@ class UpdateCheck(
         }
     }
 
-    private suspend fun refreshAuthToken(): Boolean = try {
-        authAccount.refresh()
-        true
-    } catch (e: AuthTokenStartIntent) {
-        AppLog.e("AuthToken: require interactive sing in")
-        false
-    } catch (e: Throwable) {
-        AppLog.e("AuthTokenBlocking request exception: " + e.message, e)
-        false
-    }
-
     private fun updateLocalApp(marketApp: Document, localApp: App, values: ContentValues) {
         val uploadTime = marketApp.extractUploadDate(uploadDateParserCache)
         values.put(BaseColumns._ID, localApp.rowId)
@@ -406,3 +439,48 @@ class UpdateCheck(
         }
     }
 }
+
+internal fun reconcileVersionRollback(marketVersionCode: Int, localApp: App, values: ContentValues): Boolean {
+    if (marketVersionCode >= localApp.versionNumber) {
+        return false
+    }
+    values.put(AppListTable.Columns.STATUS, App.STATUS_NORMAL)
+    values.put(AppListTable.Columns.SYNC_TIMESTAMP, 0L)
+    return true
+}
+
+internal suspend fun <T, R> fetchAllChunks(
+    chunks: List<T>,
+    maxAttempts: Int = 3,
+    initialRetryDelayMillis: Long = 250L,
+    fetch: suspend (T) -> R
+): List<Pair<T, R>> {
+    require(maxAttempts > 0)
+    require(initialRetryDelayMillis >= 0)
+    val fetched = ArrayList<Pair<T, R>>(chunks.size)
+    for (chunk in chunks) {
+        var attempt = 1
+        while (true) {
+            try {
+                fetched.add(Pair(chunk, fetch(chunk)))
+                break
+            } catch (error: Exception) {
+                if (attempt >= maxAttempts || !isTransientChunkFailure(error)) {
+                    throw error
+                }
+                AppLog.w(
+                    "Retrying Play Store chunk after attempt $attempt: ${error.message}",
+                    "UpdateCheck"
+                )
+                delay(initialRetryDelayMillis * attempt)
+                attempt++
+            }
+        }
+    }
+    return fetched
+}
+
+private fun isTransientChunkFailure(error: Exception): Boolean =
+    error is IOException ||
+        (error is DfeServerError &&
+            (error.statusCode == 429 || error.statusCode?.let { it in 500..599 } == true))

--- a/app/src/main/java/com/anod/appwatcher/sync/UpdateCheck.kt
+++ b/app/src/main/java/com/anod/appwatcher/sync/UpdateCheck.kt
@@ -144,7 +144,7 @@ class UpdateCheck(
                 SyncResult(false, listOf(), 0, 0)
             }
         } catch (e: AuthTokenStartIntent) {
-            AppLog.e("AuthToken: require interactive sing in")
+            AppLog.e("AuthToken: require interactive sign in")
             return@withContext finishFailedSync(schedule, Schedule.STATUS_FAILED_NO_TOKEN, manualSync)
         } catch (e: AuthTokenUnavailableException) {
             AppLog.e("Cannot receive access token", e)

--- a/app/src/main/java/com/anod/appwatcher/sync/UpdateCheck.kt
+++ b/app/src/main/java/com/anod/appwatcher/sync/UpdateCheck.kt
@@ -10,6 +10,7 @@ import androidx.work.Data
 import com.anod.appwatcher.accounts.AuthAccountInitializer
 import com.anod.appwatcher.accounts.AuthTokenStartIntent
 import com.anod.appwatcher.accounts.AuthTokenUnavailableException
+import com.anod.appwatcher.accounts.PlaySessionCoordinator
 import com.anod.appwatcher.backup.gdrive.GDriveSilentSignIn
 import com.anod.appwatcher.backup.gdrive.GDriveSync
 import com.anod.appwatcher.database.AppListTable
@@ -41,8 +42,6 @@ import java.util.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.koin.core.Koin
 import org.koin.core.parameter.parametersOf
@@ -61,6 +60,7 @@ class UpdateCheck(
     private val networkConnection: NetworkConnectivity,
     private val authAccount: AuthAccountInitializer,
     private val uploadDateParserCache: UploadDateParserCache,
+    private val playSessionCoordinator: PlaySessionCoordinator,
     private val koin: Koin
 ) {
 
@@ -78,10 +78,9 @@ class UpdateCheck(
     companion object {
         private const val ONE_SEC_IN_MILLIS = 1000
         private const val BULK_SIZE = 20
-        private const val MAX_CHUNK_ATTEMPTS = 3
+        internal const val MAX_CHUNK_ATTEMPTS = 3
         private const val CHUNK_RETRY_DELAY_MILLIS = 250L
         internal const val EXTRAS_MANUAL = "manual"
-        private val syncMutex = Mutex()
 
         const val SYNC_STOP = "com.anod.appwatcher.sync.start"
         const val SYNC_PROGRESS = "com.anod.appwatcher.sync.progress"
@@ -90,7 +89,7 @@ class UpdateCheck(
 
     private val installedAppsProvider = InstalledApps.PackageManager(packageManager)
 
-    suspend fun perform(extras: Data): Int = syncMutex.withLock {
+    suspend fun perform(extras: Data): Int = playSessionCoordinator.withSession {
         performSerialized(extras)
     }
 
@@ -125,25 +124,24 @@ class UpdateCheck(
 
         val lastUpdatesViewed = preferences.isLastUpdatesViewed
         val syncResult = try {
-            authAccount.withRefreshedAccount {
-                val startIntent = Intent(SYNC_PROGRESS).apply {
-                    `package` = context.actual.packageName
-                }
-                context.sendBroadcast(startIntent)
+            authAccount.refreshInSession()
+            val startIntent = Intent(SYNC_PROGRESS).apply {
+                `package` = context.actual.packageName
+            }
+            context.sendBroadcast(startIntent)
 
-                AppLog.d("Last update viewed: $lastUpdatesViewed")
-                SchedulesTable.Queries.save(schedule, database)
+            AppLog.d("Last update viewed: $lastUpdatesViewed")
+            SchedulesTable.Queries.save(schedule, database)
 
-                try {
-                    doSync(lastUpdatesViewed)
-                } catch (e: AuthTokenStartIntent) {
-                    throw e
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    AppLog.e("Error during synchronization ${e.message}", e)
-                    SyncResult(false, listOf(), 0, 0)
-                }
+            try {
+                doSync(lastUpdatesViewed)
+            } catch (e: AuthTokenStartIntent) {
+                throw e
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLog.e("Error during synchronization ${e.message}", e)
+                SyncResult(false, listOf(), 0, 0)
             }
         } catch (e: AuthTokenStartIntent) {
             AppLog.e("AuthToken: require interactive sing in")
@@ -303,18 +301,31 @@ class UpdateCheck(
             return emptyList()
         }
 
-        db.applyAppSyncUpdates(
-            pendingUpdates.map { update ->
-                AppSyncUpdate(
-                    rowId = update.rowId,
-                    expectedAppId = update.expectedAppId,
-                    expectedPackageName = update.expectedPackageName,
-                    values = update.values,
-                    changelogValues = update.changelog
-                )
-            }
+        val updates = pendingUpdates.map { update ->
+            AppSyncUpdate(
+                rowId = update.rowId,
+                expectedAppId = update.expectedAppId,
+                expectedPackageName = update.expectedPackageName,
+                values = update.values,
+                changelogValues = update.changelog
+            )
+        }
+        val appliedRowIds = AppListTable.Queries.applySyncUpdates(
+            updates,
+            db
         )
-        return pendingUpdates.mapNotNull { it.updatedApp }
+        val skippedRowIds = updates
+            .map { it.rowId }
+            .filterNot { it in appliedRowIds }
+        if (skippedRowIds.isNotEmpty()) {
+            AppLog.w(
+                "Skipped app rows changed during synchronization: ${skippedRowIds.joinToString()}",
+                "UpdateCheck"
+            )
+        }
+        return pendingUpdates
+            .filter { it.rowId in appliedRowIds }
+            .mapNotNull { it.updatedApp }
     }
 
     private fun updateApp(marketDoc: Document, localItem: AppListItem, lastUpdatesViewed: Boolean): Pair<ContentValues, UpdatedApp?> {
@@ -451,8 +462,8 @@ internal fun reconcileVersionRollback(marketVersionCode: Int, localApp: App, val
 
 internal suspend fun <T, R> fetchAllChunks(
     chunks: List<T>,
-    maxAttempts: Int = 3,
-    initialRetryDelayMillis: Long = 250L,
+    maxAttempts: Int,
+    initialRetryDelayMillis: Long,
     fetch: suspend (T) -> R
 ): List<Pair<T, R>> {
     require(maxAttempts > 0)

--- a/app/src/main/java/com/anod/appwatcher/utils/PlaystoreAuthTokenProvider.kt
+++ b/app/src/main/java/com/anod/appwatcher/utils/PlaystoreAuthTokenProvider.kt
@@ -2,6 +2,7 @@ package com.anod.appwatcher.utils
 
 import com.anod.appwatcher.accounts.AuthTokenBlocking
 import com.anod.appwatcher.preferences.Preferences
+import finsky.api.DfeAuthData
 import finsky.api.DfeAuthProvider
 
 class PlaystoreAuthTokenProvider(private val authTokenBlocking: AuthTokenBlocking, private val preferences: Preferences) : DfeAuthProvider {
@@ -10,9 +11,21 @@ class PlaystoreAuthTokenProvider(private val authTokenBlocking: AuthTokenBlockin
     override val gfsToken: String
         get() = preferences.account?.gfsIdToken ?: ""
     override val authToken: String
-        get() = authTokenBlocking.token
+        get() = authTokenBlocking.tokenFor(preferences.account)
     override val accountName: String
         get() = preferences.account?.name ?: ""
     override val deviceConfigToken: String
         get() = preferences.account?.deviceConfig ?: ""
+    override val authData: DfeAuthData
+        get() {
+            val account = preferences.account
+                ?: return DfeAuthData("", "", "", "", "")
+            return DfeAuthData(
+                gfsId = account.gfsId,
+                gfsToken = account.gfsIdToken,
+                authToken = authTokenBlocking.tokenFor(account),
+                accountName = account.name,
+                deviceConfigToken = account.deviceConfig
+            )
+        }
 }

--- a/app/src/main/java/com/anod/appwatcher/watchlist/MainViewModel.kt
+++ b/app/src/main/java/com/anod/appwatcher/watchlist/MainViewModel.kt
@@ -9,10 +9,12 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.viewModelScope
 import com.anod.appwatcher.R
 import com.anod.appwatcher.accounts.AccountSelectionResult
+import com.anod.appwatcher.accounts.AccountSessionBusyException
 import com.anod.appwatcher.accounts.AuthAccount
 import com.anod.appwatcher.accounts.AuthAccountInitializer
 import com.anod.appwatcher.accounts.AuthTokenBlocking
 import com.anod.appwatcher.accounts.AuthTokenStartIntent
+import com.anod.appwatcher.accounts.DeviceRegistrationException
 import com.anod.appwatcher.accounts.toAndroidAccount
 import com.anod.appwatcher.database.AppsDatabase
 import com.anod.appwatcher.database.entities.Tag
@@ -27,6 +29,10 @@ import info.anodsplace.applog.AppLog
 import info.anodsplace.framework.content.ShowToastActionDefaults
 import info.anodsplace.framework.content.StartActivityAction
 import info.anodsplace.ktx.Hash
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -86,10 +92,13 @@ class MainViewModel : BaseFlowViewModel<MainViewState, MainViewEvent, MainViewAc
     private val authAccountInitializer: AuthAccountInitializer by inject()
     val authToken: AuthTokenBlocking by inject()
 
+    private var accountInitializationJob: Job? = null
+    private var pendingAccountInitialization: Account? = null
+
     init {
         viewState = MainViewState(
             account = prefs.account,
-            accountInitializedRetries = 2,
+            accountInitializedRetries = if (prefs.isDeviceRegistrationRequired) 0 else 2,
             lastUpdate = prefs.lastUpdateTime,
             watchListPreferences = watchListPreferences(prefs)
         )
@@ -133,9 +142,8 @@ class MainViewModel : BaseFlowViewModel<MainViewState, MainViewEvent, MainViewAc
                 }
         }
 
-        if (viewState.account == null) {
-            showAccountErrorToast("")
-            emitAction(MainViewAction.ChooseAccount(null))
+        if (viewState.account == null || prefs.isDeviceRegistrationRequired) {
+            requestDeviceRegistration()
         }
     }
 
@@ -150,7 +158,7 @@ class MainViewModel : BaseFlowViewModel<MainViewState, MainViewEvent, MainViewAc
 
                     is AccountSelectionResult.Error -> showAccountErrorToast(event.result.errorMessage)
                     is AccountSelectionResult.Success -> {
-                        onAccountSelect(event.result.account)
+                        onAccountSelect(event.result.account, userInitiated = true)
                     }
                 }
             }
@@ -177,11 +185,22 @@ class MainViewModel : BaseFlowViewModel<MainViewState, MainViewEvent, MainViewAc
     }
 
     private fun initAccount() {
-        if (viewState.accountInitializedRetries < 1) {
+        val resumingInteractiveAuth = pendingAccountInitialization != null ||
+            prefs.isDeviceRegistrationAuthorized
+        if (
+            (!resumingInteractiveAuth && viewState.accountInitializedRetries < 1) ||
+            accountInitializationJob?.isActive == true
+        ) {
             return
         }
-        val account = prefs.account?.toAndroidAccount() ?: return
-        onAccountSelect(account)
+        val account = pendingAccountInitialization
+            ?: prefs.account?.toAndroidAccount()
+            ?: return
+        onAccountSelect(
+            account,
+            userInitiated = false,
+            resumingInteractiveAuth = resumingInteractiveAuth
+        )
     }
 
     private fun onNotificationResult(enabled: Boolean) {
@@ -201,12 +220,20 @@ class MainViewModel : BaseFlowViewModel<MainViewState, MainViewEvent, MainViewAc
         }
     }
 
-    private fun onAccountSelect(account: Account) {
+    private fun onAccountSelect(
+        account: Account,
+        userInitiated: Boolean,
+        resumingInteractiveAuth: Boolean = false
+    ) {
+        if (accountInitializationJob?.isActive == true) {
+            return
+        }
         val collectReports = prefs.collectCrashReports
         val initializer = authAccountInitializer
-        viewModelScope.launch {
+        accountInitializationJob = viewModelScope.launch {
             try {
-                val authAccount = initializer.initialize(account)
+                val authAccount = initializer.initialize(account, userInitiated)
+                pendingAccountInitialization = null
                 viewState = viewState.copy(account = authAccount, accountInitializedRetries = 0)
                 if (collectReports) {
                     FirebaseCrashlytics.getInstance().setUserId(Hash.sha256(account.name).encoded)
@@ -219,14 +246,45 @@ class MainViewModel : BaseFlowViewModel<MainViewState, MainViewEvent, MainViewAc
                 }
                 upgradeCheck()
             } catch (e: AuthTokenStartIntent) {
+                currentCoroutineContext().ensureActive()
                 viewState = viewState.copy(account = prefs.account, accountInitializedRetries = viewState.accountInitializedRetries - 1)
-                emitAction(startActivityAction(e.intent))
+                if (resumingInteractiveAuth) {
+                    pendingAccountInitialization = null
+                    initializer.clearDeviceRegistrationAuthorization()
+                    showAccountErrorToast("")
+                } else {
+                    pendingAccountInitialization = account
+                    emitAction(startActivityAction(e.intent))
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: DeviceRegistrationException) {
+                currentCoroutineContext().ensureActive()
+                requestDeviceRegistration()
+            } catch (_: AccountSessionBusyException) {
+                currentCoroutineContext().ensureActive()
+                emitAction(showToastAction(
+                    resId = R.string.sync_in_progress_retry,
+                    length = Toast.LENGTH_LONG
+                ))
             } catch (e: Exception) {
+                currentCoroutineContext().ensureActive()
+                pendingAccountInitialization = null
                 viewState = viewState.copy(account = prefs.account, accountInitializedRetries = viewState.accountInitializedRetries - 1)
                 AppLog.e("Error retrieving authentication token ${e.message}")
                 showAccountErrorToast("")
             }
         }
+    }
+
+    private fun requestDeviceRegistration() {
+        pendingAccountInitialization = null
+        viewState = viewState.copy(
+            account = prefs.account,
+            accountInitializedRetries = 0
+        )
+        showAccountErrorToast("")
+        emitAction(MainViewAction.ChooseAccount(prefs.account?.toAndroidAccount()))
     }
 
     private suspend fun scheduleRefresh() {

--- a/app/src/main/java/com/anod/appwatcher/watchlist/MainViewModel.kt
+++ b/app/src/main/java/com/anod/appwatcher/watchlist/MainViewModel.kt
@@ -158,7 +158,11 @@ class MainViewModel : BaseFlowViewModel<MainViewState, MainViewEvent, MainViewAc
 
                     is AccountSelectionResult.Error -> showAccountErrorToast(event.result.errorMessage)
                     is AccountSelectionResult.Success -> {
-                        onAccountSelect(event.result.account, userInitiated = true)
+                        onAccountSelect(
+                            account = event.result.account,
+                            userInitiated = true,
+                            resumingInteractiveAuth = false
+                        )
                     }
                 }
             }
@@ -223,7 +227,7 @@ class MainViewModel : BaseFlowViewModel<MainViewState, MainViewEvent, MainViewAc
     private fun onAccountSelect(
         account: Account,
         userInitiated: Boolean,
-        resumingInteractiveAuth: Boolean = false
+        resumingInteractiveAuth: Boolean
     ) {
         if (accountInitializationJob?.isActive == true) {
             return

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -6,6 +6,7 @@
     <string name="menu_edit">Szerkesztés</string>
     <string name="menu_refresh">Ellenőrzés most</string>
     <string name="failed_gain_access">Válassz egy fiókot és engedélyezd a hozzáférést Ez szükséges a Google Play Áruházzal való kommunikációhoz.</string>
+    <string name="sync_in_progress_retry">Frissítés van folyamatban. Próbáld meg újra módosítani a fiókot, amikor befejeződött.</string>
     <string name="search_action">Keresés</string>
     <string name="search_for_app">Keress rá egy alkalmazásra és kattints rá a figyelőlistához való hozzáadáshoz.\n(Tipp: az alkalmazást közvetlenül is hozzáadhatod a Play Áruházból a \"Megosztás\" gombbal)</string>
     <string name="loading">Betöltés…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -4,6 +4,7 @@
     <string name="menu_add">Добавить</string>
     <string name="menu_refresh">Обновить</string>
     <string name="failed_gain_access">Пожалуйста разрешите доступ. Разрешение требуется для того, чтобы связаться с Google Play Маркет.</string>
+    <string name="sync_in_progress_retry">Идёт обновление. Попробуйте сменить аккаунт после его завершения.</string>
     <string name="search_action">Поиск</string>
     <string name="search_for_app">Найдите приложение и нажмите на него.\n
   ( Совет: Вы можете добавлять приложения непосредственно из Play Маркет с помощью кнопки \"Поделиться\" )</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="menu_edit">Edit</string>
     <string name="menu_refresh">Refresh</string>
     <string name="failed_gain_access">Please allow access and select an account. This required in order to communicate with Google Play Store.</string>
+    <string name="sync_in_progress_retry">A refresh is in progress. Try changing the account again when it finishes.</string>
     <string name="search_action">Search</string>
     <string name="search_for_app">Search for an application and click on it to add to the watch list.\n( Tip: you can add apps directly from Play Store using \"Share\" button )</string>
     <string name="loading">Loading…</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="DeviceRegistration.xml" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="DeviceRegistration.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="DeviceRegistration.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/test/java/com/anod/appwatcher/accounts/AuthAccountInitializerTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/AuthAccountInitializerTest.kt
@@ -37,6 +37,8 @@ class AuthAccountInitializerTest {
         runBlocking {
             preferences.saveAccount(
                 completeAccount(),
+                deviceRegistrationPending = null,
+                deviceRegistrationAuthorized = null,
                 deviceConfigRevision = DeviceRegistration.DEVICE_CONFIG_REVISION
             )
         }
@@ -56,7 +58,8 @@ class AuthAccountInitializerTest {
         val initializer = AuthAccountInitializer(
             preferences,
             AuthTokenBlocking.create(tokenProvider),
-            dfeApi
+            dfeApi,
+            PlaySessionCoordinator()
         )
 
         initializer.refresh()
@@ -77,14 +80,15 @@ class AuthAccountInitializerTest {
             deviceConfig = ""
         )
         val dfeApi = FakeDfeApi().apply {
-            uploadFailures.add(finsky.api.DfeServerError("Unauthorized", statusCode = 401))
+            uploadFailures.add(finsky.api.DfeServerError("Unauthorized", statusCode = 401, cause = null))
         }
         val tokenProvider = RecordingTokenProvider("cached-token", "fresh-token")
         val authToken = AuthTokenBlocking.create(tokenProvider)
         val initializer = AuthAccountInitializer(
             preferences,
             authToken,
-            AuthRecoveringDfeApi(dfeApi, authToken, preferences)
+            AuthRecoveringDfeApi(dfeApi, authToken, preferences),
+            PlaySessionCoordinator()
         )
 
         initializer.initialize(
@@ -118,7 +122,8 @@ class AuthAccountInitializerTest {
         val initializer = AuthAccountInitializer(
             preferences,
             AuthTokenBlocking.create(tokenProvider),
-            dfeApi
+            dfeApi,
+            PlaySessionCoordinator()
         )
         val account = Account("new@example.com", AuthTokenBlocking.ACCOUNT_TYPE)
 
@@ -140,16 +145,18 @@ class AuthAccountInitializerTest {
     @Test
     fun interactiveAccountSwitchFailsFastWhileSyncSessionIsActive() = runBlocking {
         val dfeApi = FakeDfeApi()
+        val playSessionCoordinator = PlaySessionCoordinator()
         val initializer = AuthAccountInitializer(
             preferences,
             AuthTokenBlocking.create(RecordingTokenProvider("token-a", "token-b")),
-            dfeApi
+            dfeApi,
+            playSessionCoordinator
         )
         val actionStarted = CompletableDeferred<Unit>()
         val finishAction = CompletableDeferred<Unit>()
 
         val session = async {
-            initializer.withRefreshedAccount {
+            playSessionCoordinator.withSession {
                 actionStarted.complete(Unit)
                 finishAction.await()
             }
@@ -178,11 +185,13 @@ class AuthAccountInitializerTest {
 
     @Test
     fun accountSwitchesReuseDeviceIdentityAcrossInitializers() = runBlocking {
+        val playSessionCoordinator = PlaySessionCoordinator()
         val accountBApi = FakeDfeApi()
         val accountBInitializer = AuthAccountInitializer(
             preferences,
             AuthTokenBlocking.create(RecordingTokenProvider("token-b")),
-            accountBApi
+            accountBApi,
+            playSessionCoordinator
         )
 
         accountBInitializer.initialize(
@@ -197,7 +206,8 @@ class AuthAccountInitializerTest {
         val recreatedInitializer = AuthAccountInitializer(
             preferences,
             AuthTokenBlocking.create(RecordingTokenProvider("token-a")),
-            accountAApi
+            accountAApi,
+            playSessionCoordinator
         )
 
         recreatedInitializer.initialize(
@@ -216,7 +226,8 @@ class AuthAccountInitializerTest {
         val initializer = AuthAccountInitializer(
             preferences,
             AuthTokenBlocking.create(tokenProvider),
-            dfeApi
+            dfeApi,
+            PlaySessionCoordinator()
         )
 
         initializer.initialize(

--- a/app/src/test/java/com/anod/appwatcher/accounts/AuthAccountInitializerTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/AuthAccountInitializerTest.kt
@@ -1,0 +1,259 @@
+package com.anod.appwatcher.accounts
+
+import android.accounts.Account
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.anod.appwatcher.preferences.Preferences
+import info.anodsplace.notification.NotificationManager
+import java.io.IOException
+import java.util.ArrayDeque
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class AuthAccountInitializerTest {
+    private lateinit var preferences: Preferences
+
+    @Before
+    fun setUp() {
+        preferences = Preferences(
+            context = ApplicationProvider.getApplicationContext(),
+            notificationManager = NotificationManager.NoOp(),
+            appScope = CoroutineScope(Dispatchers.Unconfined)
+        )
+        runBlocking {
+            preferences.saveAccount(
+                completeAccount(),
+                deviceConfigRevision = DeviceRegistration.DEVICE_CONFIG_REVISION
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        preferences.account = null
+    }
+
+    @Test
+    fun routineRefreshDoesNotProbeArbitraryValidationPackage() = runBlocking {
+        val dfeApi = FakeDfeApi().apply {
+            detailsFailures.add(IOException("offline"))
+        }
+        val tokenProvider = RecordingTokenProvider("cached-token")
+        val initializer = AuthAccountInitializer(
+            preferences,
+            AuthTokenBlocking.create(tokenProvider),
+            dfeApi
+        )
+
+        initializer.refresh()
+
+        assertEquals(0, dfeApi.checkInCalls)
+        assertEquals(0, dfeApi.detailsCalls)
+        assertEquals(emptyList<String>(), tokenProvider.invalidatedTokens)
+        assertEquals(completeAccount(), preferences.account)
+    }
+
+    @Test
+    fun registrationAuthenticationFailureRetriesUploadWithoutAnotherCheckin() = runBlocking {
+        preferences.account = AuthAccount(
+            name = "new@example.com",
+            type = AuthTokenBlocking.ACCOUNT_TYPE,
+            gfsId = "",
+            gfsIdToken = "",
+            deviceConfig = ""
+        )
+        val dfeApi = FakeDfeApi().apply {
+            uploadFailures.add(finsky.api.DfeServerError("Unauthorized", statusCode = 401))
+        }
+        val tokenProvider = RecordingTokenProvider("cached-token", "fresh-token")
+        val authToken = AuthTokenBlocking.create(tokenProvider)
+        val initializer = AuthAccountInitializer(
+            preferences,
+            authToken,
+            AuthRecoveringDfeApi(dfeApi, authToken, preferences)
+        )
+
+        initializer.initialize(
+            Account("new@example.com", AuthTokenBlocking.ACCOUNT_TYPE),
+            userInitiated = true
+        )
+
+        assertEquals(1, dfeApi.checkInCalls)
+        assertEquals(2, dfeApi.uploadCalls)
+        assertEquals(listOf("cached-token"), tokenProvider.invalidatedTokens)
+        assertEquals("4d2", preferences.account?.gfsId)
+        assertEquals("config-token", preferences.account?.deviceConfig)
+    }
+
+    @Test
+    fun interactiveTokenFlowRetainsOneShotRegistrationAuthorization() = runBlocking {
+        preferences.account = null
+        var tokenRequests = 0
+        val tokenProvider = object : AccountAuthTokenProvider {
+            override fun getAuthToken(account: Account): String {
+                tokenRequests++
+                if (tokenRequests == 1) {
+                    throw AuthTokenStartIntent(Intent())
+                }
+                return "token"
+            }
+
+            override fun invalidateAuthToken(token: String) = Unit
+        }
+        val dfeApi = FakeDfeApi()
+        val initializer = AuthAccountInitializer(
+            preferences,
+            AuthTokenBlocking.create(tokenProvider),
+            dfeApi
+        )
+        val account = Account("new@example.com", AuthTokenBlocking.ACCOUNT_TYPE)
+
+        try {
+            initializer.initialize(account, userInitiated = true)
+            throw AssertionError("Expected interactive authentication")
+        } catch (_: AuthTokenStartIntent) {
+        }
+
+        assertTrue(preferences.isDeviceRegistrationAuthorized)
+        assertEquals(0, dfeApi.checkInCalls)
+
+        initializer.initialize(account, userInitiated = false)
+
+        assertFalse(preferences.isDeviceRegistrationAuthorized)
+        assertEquals(1, dfeApi.checkInCalls)
+    }
+
+    @Test
+    fun interactiveAccountSwitchFailsFastWhileSyncSessionIsActive() = runBlocking {
+        val dfeApi = FakeDfeApi()
+        val initializer = AuthAccountInitializer(
+            preferences,
+            AuthTokenBlocking.create(RecordingTokenProvider("token-a", "token-b")),
+            dfeApi
+        )
+        val actionStarted = CompletableDeferred<Unit>()
+        val finishAction = CompletableDeferred<Unit>()
+
+        val session = async {
+            initializer.withRefreshedAccount {
+                actionStarted.complete(Unit)
+                finishAction.await()
+            }
+        }
+        actionStarted.await()
+
+        try {
+            initializer.initialize(
+                Account("b@example.com", AuthTokenBlocking.ACCOUNT_TYPE),
+                userInitiated = true
+            )
+            throw AssertionError("Expected active synchronization failure")
+        } catch (_: AccountSessionBusyException) {
+        }
+        assertEquals("account@example.com", preferences.account?.name)
+
+        finishAction.complete(Unit)
+        session.await()
+        initializer.initialize(
+            Account("b@example.com", AuthTokenBlocking.ACCOUNT_TYPE),
+            userInitiated = true
+        )
+
+        assertEquals("b@example.com", preferences.account?.name)
+    }
+
+    @Test
+    fun accountSwitchesReuseDeviceIdentityAcrossInitializers() = runBlocking {
+        val accountBApi = FakeDfeApi()
+        val accountBInitializer = AuthAccountInitializer(
+            preferences,
+            AuthTokenBlocking.create(RecordingTokenProvider("token-b")),
+            accountBApi
+        )
+
+        accountBInitializer.initialize(
+            Account("b@example.com", AuthTokenBlocking.ACCOUNT_TYPE),
+            userInitiated = true
+        )
+
+        assertEquals(0, accountBApi.checkInCalls)
+        assertEquals("existing-id", preferences.account?.gfsId)
+
+        val accountAApi = FakeDfeApi()
+        val recreatedInitializer = AuthAccountInitializer(
+            preferences,
+            AuthTokenBlocking.create(RecordingTokenProvider("token-a")),
+            accountAApi
+        )
+
+        recreatedInitializer.initialize(
+            Account("account@example.com", AuthTokenBlocking.ACCOUNT_TYPE),
+            userInitiated = true
+        )
+
+        assertEquals(0, accountAApi.checkInCalls)
+        assertEquals("existing-id", preferences.account?.gfsId)
+    }
+
+    @Test
+    fun staleAutomaticInitializationDoesNotRestorePreviousAccount() = runBlocking {
+        val dfeApi = FakeDfeApi()
+        val tokenProvider = RecordingTokenProvider("token-b")
+        val initializer = AuthAccountInitializer(
+            preferences,
+            AuthTokenBlocking.create(tokenProvider),
+            dfeApi
+        )
+
+        initializer.initialize(
+            Account("b@example.com", AuthTokenBlocking.ACCOUNT_TYPE),
+            userInitiated = true
+        )
+
+        val result = initializer.initialize(
+            Account("account@example.com", AuthTokenBlocking.ACCOUNT_TYPE),
+            userInitiated = false
+        )
+
+        assertEquals("b@example.com", result.name)
+        assertEquals("b@example.com", preferences.account?.name)
+        assertEquals(1, tokenProvider.requestedAccounts.size)
+    }
+
+    private fun completeAccount() = AuthAccount(
+        name = "account@example.com",
+        type = AuthTokenBlocking.ACCOUNT_TYPE,
+        gfsId = "existing-id",
+        gfsIdToken = "existing-checkin",
+        deviceConfig = "existing-config"
+    )
+
+    private class RecordingTokenProvider(vararg tokens: String) : AccountAuthTokenProvider {
+        private val tokens = ArrayDeque(tokens.toList())
+        val invalidatedTokens = mutableListOf<String>()
+        val requestedAccounts = mutableListOf<String>()
+
+        override fun getAuthToken(account: Account): String {
+            requestedAccounts.add(account.name)
+            return tokens.removeFirst()
+        }
+
+        override fun invalidateAuthToken(token: String) {
+            invalidatedTokens.add(token)
+        }
+    }
+}

--- a/app/src/test/java/com/anod/appwatcher/accounts/AuthRecoveringDfeApiTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/AuthRecoveringDfeApiTest.kt
@@ -51,7 +51,7 @@ class AuthRecoveringDfeApiTest {
         val authToken = AuthTokenBlocking.create(tokenProvider)
         authToken.refreshToken(Account("account@example.com", AuthTokenBlocking.ACCOUNT_TYPE))
         val delegate = FakeDfeApi().apply {
-            detailsFailures.add(DfeServerError("Unauthorized", statusCode = 401))
+            detailsFailures.add(DfeServerError("Unauthorized", statusCode = 401, cause = null))
             detailsResponse = Details.DetailsResponse.getDefaultInstance()
         }
         val dfeApi = AuthRecoveringDfeApi(delegate, authToken, preferences)

--- a/app/src/test/java/com/anod/appwatcher/accounts/AuthRecoveringDfeApiTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/AuthRecoveringDfeApiTest.kt
@@ -1,0 +1,76 @@
+package com.anod.appwatcher.accounts
+
+import android.accounts.Account
+import androidx.test.core.app.ApplicationProvider
+import com.anod.appwatcher.preferences.Preferences
+import finsky.api.DfeServerError
+import finsky.protos.Details
+import info.anodsplace.notification.NotificationManager
+import java.util.ArrayDeque
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AuthRecoveringDfeApiTest {
+    private lateinit var preferences: Preferences
+
+    @Before
+    fun setUp() {
+        preferences = Preferences(
+            context = ApplicationProvider.getApplicationContext(),
+            notificationManager = NotificationManager.NoOp(),
+            appScope = CoroutineScope(Dispatchers.Unconfined)
+        )
+        preferences.account = AuthAccount(
+            name = "account@example.com",
+            type = AuthTokenBlocking.ACCOUNT_TYPE,
+            gfsId = "device",
+            gfsIdToken = "checkin",
+            deviceConfig = "config"
+        )
+    }
+
+    @After
+    fun tearDown() {
+        preferences.account = null
+    }
+
+    @Test
+    fun directRequestRefreshesRejectedTokenOnce() = runBlocking {
+        val tokenProvider = RecordingTokenProvider(
+            "expired-token",
+            "fresh-token"
+        )
+        val authToken = AuthTokenBlocking.create(tokenProvider)
+        authToken.refreshToken(Account("account@example.com", AuthTokenBlocking.ACCOUNT_TYPE))
+        val delegate = FakeDfeApi().apply {
+            detailsFailures.add(DfeServerError("Unauthorized", statusCode = 401))
+            detailsResponse = Details.DetailsResponse.getDefaultInstance()
+        }
+        val dfeApi = AuthRecoveringDfeApi(delegate, authToken, preferences)
+
+        dfeApi.details("details?doc=example")
+
+        assertEquals(2, delegate.detailsCalls)
+        assertEquals(listOf("expired-token"), tokenProvider.invalidatedTokens)
+        assertEquals("fresh-token", authToken.token)
+    }
+
+    private class RecordingTokenProvider(vararg tokens: String) : AccountAuthTokenProvider {
+        private val tokens = ArrayDeque(tokens.toList())
+        val invalidatedTokens = mutableListOf<String>()
+
+        override fun getAuthToken(account: Account): String = tokens.removeFirst()
+
+        override fun invalidateAuthToken(token: String) {
+            invalidatedTokens.add(token)
+        }
+    }
+}

--- a/app/src/test/java/com/anod/appwatcher/accounts/AuthTokenBlockingTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/AuthTokenBlockingTest.kt
@@ -1,0 +1,152 @@
+package com.anod.appwatcher.accounts
+
+import android.accounts.Account
+import java.util.ArrayDeque
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AuthTokenBlockingTest {
+
+    @Test
+    fun routineRefreshDoesNotInvalidateToken() = runBlocking {
+        val provider = RecordingTokenProvider("cached-token")
+        val authToken = AuthTokenBlocking.create(provider)
+
+        val result = authToken.refreshToken(account())
+
+        assertTrue(result is CheckTokenResult.Success)
+        assertFalse((result as CheckTokenResult.Success).invalidated)
+        assertEquals(emptyList<String>(), provider.invalidatedTokens)
+        assertEquals("cached-token", authToken.token)
+    }
+
+    @Test
+    fun explicitAuthenticationRecoveryInvalidatesTokenOnce() = runBlocking {
+        val provider = RecordingTokenProvider("expired-token", "fresh-token")
+        val authToken = AuthTokenBlocking.create(provider)
+
+        val result = authToken.invalidateAndRefreshToken(account())
+
+        assertTrue(result is CheckTokenResult.Success)
+        assertTrue((result as CheckTokenResult.Success).invalidated)
+        assertEquals(listOf("expired-token"), provider.invalidatedTokens)
+        assertEquals("fresh-token", authToken.token)
+    }
+
+    @Test
+    fun concurrentRecoveryDoesNotInvalidateReplacementToken() = runBlocking {
+        val provider = RecordingTokenProvider("expired-token", "fresh-token")
+        val authToken = AuthTokenBlocking.create(provider)
+        val account = account()
+        authToken.refreshToken(account)
+
+        val first = authToken.refreshAfterAuthenticationFailure(account, "expired-token")
+        val second = authToken.refreshAfterAuthenticationFailure(account, "expired-token")
+
+        assertTrue((first as CheckTokenResult.Success).invalidated)
+        assertFalse((second as CheckTokenResult.Success).invalidated)
+        assertEquals(listOf("expired-token"), provider.invalidatedTokens)
+        assertEquals("fresh-token", authToken.token)
+    }
+
+    @Test
+    fun rejectedTokenRemainsAvailableWhileReplacementIsLoading() = runBlocking {
+        val provider = BlockingReplacementTokenProvider()
+        val authToken = AuthTokenBlocking.create(provider)
+        val account = account()
+        authToken.refreshToken(account)
+
+        val recovery = async(Dispatchers.Default) {
+            authToken.refreshAfterAuthenticationFailure(account, "expired-token")
+        }
+        try {
+            assertTrue(provider.replacementRequested.await(5, TimeUnit.SECONDS))
+            assertEquals("expired-token", authToken.tokenFor(authAccount()))
+        } finally {
+            provider.releaseReplacement.countDown()
+        }
+
+        assertTrue((recovery.await() as CheckTokenResult.Success).invalidated)
+        assertEquals("fresh-token", authToken.tokenFor(authAccount()))
+    }
+
+    @Test
+    fun freshTokenIsNotReusedForAnotherAccount() = runBlocking {
+        val provider = RecordingTokenProvider("first-token", "second-token")
+        val authToken = AuthTokenBlocking.create(provider)
+
+        authToken.refreshToken(account("first@example.com"))
+        authToken.checkToken(account("second@example.com"))
+
+        assertEquals("second-token", authToken.token)
+        assertEquals(
+            listOf("first@example.com", "second@example.com"),
+            provider.requestedAccounts
+        )
+        assertEquals(
+            "",
+            authToken.tokenFor(
+                AuthAccount(
+                    name = "first@example.com",
+                    type = AuthTokenBlocking.ACCOUNT_TYPE,
+                    gfsId = "device",
+                    gfsIdToken = "checkin",
+                    deviceConfig = "config"
+                )
+            )
+        )
+    }
+
+    private fun account(name: String = "account@example.com") = Account(name, AuthTokenBlocking.ACCOUNT_TYPE)
+
+    private fun authAccount() = AuthAccount(
+        name = "account@example.com",
+        type = AuthTokenBlocking.ACCOUNT_TYPE,
+        gfsId = "device",
+        gfsIdToken = "checkin",
+        deviceConfig = "config"
+    )
+
+    private class RecordingTokenProvider(vararg tokens: String) : AccountAuthTokenProvider {
+        private val tokens = ArrayDeque(tokens.toList())
+        val invalidatedTokens = mutableListOf<String>()
+        val requestedAccounts = mutableListOf<String>()
+
+        override fun getAuthToken(account: Account): String {
+            requestedAccounts.add(account.name)
+            return tokens.removeFirst()
+        }
+
+        override fun invalidateAuthToken(token: String) {
+            invalidatedTokens.add(token)
+        }
+    }
+
+    private class BlockingReplacementTokenProvider : AccountAuthTokenProvider {
+        val replacementRequested = CountDownLatch(1)
+        val releaseReplacement = CountDownLatch(1)
+        private var requests = 0
+
+        override fun getAuthToken(account: Account): String {
+            requests++
+            if (requests == 1) {
+                return "expired-token"
+            }
+            replacementRequested.countDown()
+            check(releaseReplacement.await(5, TimeUnit.SECONDS))
+            return "fresh-token"
+        }
+
+        override fun invalidateAuthToken(token: String) = Unit
+    }
+}

--- a/app/src/test/java/com/anod/appwatcher/accounts/DeviceRegistrationTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/DeviceRegistrationTest.kt
@@ -52,11 +52,14 @@ class DeviceRegistrationTest {
         assertTrue(
             preferences.saveAccount(
                 account,
+                deviceRegistrationPending = null,
+                deviceRegistrationAuthorized = null,
                 deviceConfigRevision = DeviceRegistration.DEVICE_CONFIG_REVISION
             )
         )
 
-        val result = DeviceRegistration(preferences, dfeApi, sdkInt = 35).ensure(account)
+        val result = DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+            .ensure(account, allowCheckIn = false)
 
         assertEquals(account, result)
         assertEquals(0, dfeApi.checkInCalls)
@@ -67,14 +70,22 @@ class DeviceRegistrationTest {
     fun legacyConfigTokenIsReboundWithoutNewCheckin() = runBlocking {
         val dfeApi = FakeDfeApi()
         val account = account(gfsId = "existing-id", gfsToken = "existing-checkin", deviceConfig = "legacy-config")
-        assertTrue(preferences.saveAccount(account, deviceConfigRevision = 0))
+        assertTrue(
+            preferences.saveAccount(
+                account,
+                deviceRegistrationPending = null,
+                deviceRegistrationAuthorized = null,
+                deviceConfigRevision = 0
+            )
+        )
 
-        val result = DeviceRegistration(preferences, dfeApi, sdkInt = 35).ensure(account)
+        val result = DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+            .ensure(account, allowCheckIn = false)
 
         assertEquals(0, dfeApi.checkInCalls)
         assertEquals(1, dfeApi.uploadCalls)
         assertEquals(
-            DfeDeviceIdentity("existing-id", "existing-checkin"),
+            DfeDeviceIdentity("existing-id", "existing-checkin", ""),
             dfeApi.uploadIdentities.single()
         )
         assertEquals("config-token", result.deviceConfig)
@@ -92,7 +103,7 @@ class DeviceRegistrationTest {
         assertEquals("checkin-token", result.gfsIdToken)
         assertEquals("config-token", result.deviceConfig)
         assertEquals(
-            listOf(DfeDeviceIdentity("4d2", "checkin-token")),
+            listOf(DfeDeviceIdentity("4d2", "checkin-token", "")),
             dfeApi.uploadIdentities
         )
         assertEquals(result, preferences.account)
@@ -119,7 +130,7 @@ class DeviceRegistrationTest {
         assertEquals(1, dfeApi.checkInCalls)
 
         dfeApi.uploadFailure = null
-        val result = registration.ensure(pendingAccount!!)
+        val result = registration.ensure(pendingAccount!!, allowCheckIn = false)
 
         assertEquals("config-token", result.deviceConfig)
         assertEquals(1, dfeApi.checkInCalls)
@@ -127,17 +138,26 @@ class DeviceRegistrationTest {
     }
 
     @Test
-    fun concurrentRegistrationCreatesOnlyOneIdentity() = runBlocking {
+    fun sessionCoordinatorSerializesConcurrentRegistration() = runBlocking {
         val dfeApi = FakeDfeApi().apply {
             beforeCheckIn = { delay(50) }
         }
         val registration = DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+        val playSessionCoordinator = PlaySessionCoordinator()
         val account = account()
 
         val results = coroutineScope {
             awaitAll(
-                async { registration.ensure(account, allowCheckIn = true) },
-                async { registration.ensure(account, allowCheckIn = true) }
+                async {
+                    playSessionCoordinator.withSession {
+                        registration.ensure(account, allowCheckIn = true)
+                    }
+                },
+                async {
+                    playSessionCoordinator.withSession {
+                        registration.ensure(account, allowCheckIn = true)
+                    }
+                }
             )
         }
 
@@ -168,7 +188,7 @@ class DeviceRegistrationTest {
 
         assertEquals("4d2", preferences.account?.gfsId)
         assertFalse(preferences.isDeviceRegistrationPending)
-        val result = registration.ensure(preferences.account!!)
+        val result = registration.ensure(preferences.account!!, allowCheckIn = false)
         assertEquals("4d2", result.gfsId)
         assertEquals(1, dfeApi.checkInCalls)
     }
@@ -191,7 +211,8 @@ class DeviceRegistrationTest {
         assertEquals(1, dfeApi.checkInCalls)
 
         try {
-            DeviceRegistration(preferences, dfeApi, sdkInt = 35).ensure(account)
+            DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+                .ensure(account, allowCheckIn = false)
             throw AssertionError("Expected pending registration failure")
         } catch (_: DeviceRegistrationPendingException) {
         }
@@ -210,7 +231,8 @@ class DeviceRegistrationTest {
         val dfeApi = FakeDfeApi()
 
         try {
-            DeviceRegistration(preferences, dfeApi, sdkInt = 35).ensure(account())
+            DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+                .ensure(account(), allowCheckIn = false)
             throw AssertionError("Expected registration requirement")
         } catch (_: DeviceRegistrationRequiredException) {
         }

--- a/app/src/test/java/com/anod/appwatcher/accounts/DeviceRegistrationTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/DeviceRegistrationTest.kt
@@ -1,0 +1,312 @@
+package com.anod.appwatcher.accounts
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.anod.appwatcher.preferences.Preferences
+import finsky.api.DfeDeviceIdentity
+import info.anodsplace.notification.NotificationManager
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class DeviceRegistrationTest {
+    private lateinit var preferences: Preferences
+
+    @Before
+    fun setUp() {
+        preferences = Preferences(
+            context = ApplicationProvider.getApplicationContext(),
+            notificationManager = NotificationManager.NoOp(),
+            appScope = CoroutineScope(Dispatchers.Unconfined)
+        )
+        preferences.account = null
+    }
+
+    @After
+    fun tearDown() {
+        preferences.account = null
+    }
+
+    @Test
+    fun completeIdentityIsReused() = runBlocking {
+        val dfeApi = FakeDfeApi()
+        val account = account(gfsId = "existing-id", gfsToken = "existing-checkin", deviceConfig = "existing-config")
+        assertTrue(
+            preferences.saveAccount(
+                account,
+                deviceConfigRevision = DeviceRegistration.DEVICE_CONFIG_REVISION
+            )
+        )
+
+        val result = DeviceRegistration(preferences, dfeApi, sdkInt = 35).ensure(account)
+
+        assertEquals(account, result)
+        assertEquals(0, dfeApi.checkInCalls)
+        assertEquals(0, dfeApi.uploadCalls)
+    }
+
+    @Test
+    fun legacyConfigTokenIsReboundWithoutNewCheckin() = runBlocking {
+        val dfeApi = FakeDfeApi()
+        val account = account(gfsId = "existing-id", gfsToken = "existing-checkin", deviceConfig = "legacy-config")
+        assertTrue(preferences.saveAccount(account, deviceConfigRevision = 0))
+
+        val result = DeviceRegistration(preferences, dfeApi, sdkInt = 35).ensure(account)
+
+        assertEquals(0, dfeApi.checkInCalls)
+        assertEquals(1, dfeApi.uploadCalls)
+        assertEquals(
+            DfeDeviceIdentity("existing-id", "existing-checkin"),
+            dfeApi.uploadIdentities.single()
+        )
+        assertEquals("config-token", result.deviceConfig)
+        assertEquals(DeviceRegistration.DEVICE_CONFIG_REVISION, preferences.deviceConfigRevision)
+    }
+
+    @Test
+    fun newIdentityIsUsedForDeviceConfigUpload() = runBlocking {
+        val dfeApi = FakeDfeApi()
+
+        val result = DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+            .ensure(account(), allowCheckIn = true)
+
+        assertEquals("4d2", result.gfsId)
+        assertEquals("checkin-token", result.gfsIdToken)
+        assertEquals("config-token", result.deviceConfig)
+        assertEquals(
+            listOf(DfeDeviceIdentity("4d2", "checkin-token")),
+            dfeApi.uploadIdentities
+        )
+        assertEquals(result, preferences.account)
+    }
+
+    @Test
+    fun failedConfigUploadKeepsPendingIdentityForRetry() = runBlocking {
+        val dfeApi = FakeDfeApi().apply {
+            uploadFailure = IOException("offline")
+        }
+        val registration = DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+
+        try {
+            registration.ensure(account(), allowCheckIn = true)
+            throw AssertionError("Expected upload failure")
+        } catch (_: IOException) {
+        }
+
+        val pendingAccount = preferences.account
+        assertEquals("4d2", pendingAccount?.gfsId)
+        assertEquals("checkin-token", pendingAccount?.gfsIdToken)
+        assertTrue(pendingAccount?.deviceConfig.isNullOrEmpty())
+        assertEquals(false, preferences.isDeviceRegistrationPending)
+        assertEquals(1, dfeApi.checkInCalls)
+
+        dfeApi.uploadFailure = null
+        val result = registration.ensure(pendingAccount!!)
+
+        assertEquals("config-token", result.deviceConfig)
+        assertEquals(1, dfeApi.checkInCalls)
+        assertEquals(2, dfeApi.uploadCalls)
+    }
+
+    @Test
+    fun concurrentRegistrationCreatesOnlyOneIdentity() = runBlocking {
+        val dfeApi = FakeDfeApi().apply {
+            beforeCheckIn = { delay(50) }
+        }
+        val registration = DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+        val account = account()
+
+        val results = coroutineScope {
+            awaitAll(
+                async { registration.ensure(account, allowCheckIn = true) },
+                async { registration.ensure(account, allowCheckIn = true) }
+            )
+        }
+
+        assertEquals(1, dfeApi.checkInCalls)
+        assertEquals(1, dfeApi.uploadCalls)
+        assertEquals(results[0], results[1])
+    }
+
+    @Test
+    fun cancelledCallerStillPersistsReturnedIdentity() = runBlocking {
+        val checkInStarted = CompletableDeferred<Unit>()
+        val releaseCheckIn = CompletableDeferred<Unit>()
+        val dfeApi = FakeDfeApi().apply {
+            beforeCheckIn = {
+                checkInStarted.complete(Unit)
+                releaseCheckIn.await()
+            }
+        }
+        val registration = DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+        val registrationJob = launch {
+            registration.ensure(account(), allowCheckIn = true)
+        }
+        checkInStarted.await()
+
+        registrationJob.cancel()
+        releaseCheckIn.complete(Unit)
+        registrationJob.join()
+
+        assertEquals("4d2", preferences.account?.gfsId)
+        assertFalse(preferences.isDeviceRegistrationPending)
+        val result = registration.ensure(preferences.account!!)
+        assertEquals("4d2", result.gfsId)
+        assertEquals(1, dfeApi.checkInCalls)
+    }
+
+    @Test
+    fun ambiguousCheckinFailureIsNotRetriedAutomatically() = runBlocking {
+        val dfeApi = FakeDfeApi().apply {
+            checkInFailures.add(IOException("response lost"))
+        }
+        val account = account()
+
+        try {
+            DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+                .ensure(account, allowCheckIn = true)
+            throw AssertionError("Expected check-in failure")
+        } catch (_: IOException) {
+        }
+
+        assertEquals(true, preferences.isDeviceRegistrationPending)
+        assertEquals(1, dfeApi.checkInCalls)
+
+        try {
+            DeviceRegistration(preferences, dfeApi, sdkInt = 35).ensure(account)
+            throw AssertionError("Expected pending registration failure")
+        } catch (_: DeviceRegistrationPendingException) {
+        }
+
+        assertEquals(1, dfeApi.checkInCalls)
+
+        val result = DeviceRegistration(preferences, dfeApi, sdkInt = 35)
+            .ensure(account, allowCheckIn = true)
+
+        assertEquals("4d2", result.gfsId)
+        assertEquals(2, dfeApi.checkInCalls)
+    }
+
+    @Test
+    fun routineRegistrationRequiresExplicitConfirmation() = runBlocking {
+        val dfeApi = FakeDfeApi()
+
+        try {
+            DeviceRegistration(preferences, dfeApi, sdkInt = 35).ensure(account())
+            throw AssertionError("Expected registration requirement")
+        } catch (_: DeviceRegistrationRequiredException) {
+        }
+
+        assertEquals(0, dfeApi.checkInCalls)
+        assertEquals(false, preferences.isDeviceRegistrationPending)
+    }
+
+    @Test
+    fun sameDeviceUpgradeMovesRegistrationOutOfBackupPreferences() {
+        val legacyPreferences = testPreferences("upgrade-legacy")
+        val devicePreferences = testPreferences("upgrade-device")
+        legacyPreferences.edit()
+            .putString("account_name", "user@example.com")
+            .putString("account_type", "com.google")
+            .putString("gfs_id", "123")
+            .putString("gfs_token", "token")
+            .putString("device_config", "config")
+            .putBoolean("device_registration_pending", true)
+            .putBoolean("device_registration_authorized", true)
+            .putInt("device_config_revision", 1)
+            .commit()
+
+        Preferences.migrateDeviceRegistrationPreferences(
+            legacyPreferences,
+            devicePreferences,
+            isSameDeviceUpgrade = true,
+            wasRestored = false
+        )
+
+        assertEquals("user@example.com", devicePreferences.getString("account_name", null))
+        assertEquals("123", devicePreferences.getString("gfs_id", null))
+        assertTrue(devicePreferences.getBoolean("device_registration_pending", false))
+        assertFalse(legacyPreferences.contains("account_name"))
+        assertFalse(legacyPreferences.contains("gfs_id"))
+    }
+
+    @Test
+    fun restoredRegistrationIsDiscarded() {
+        val legacyPreferences = testPreferences("restore-legacy")
+        val devicePreferences = testPreferences("restore-device")
+        legacyPreferences.edit()
+            .putString("account_name", "user@example.com")
+            .putString("account_type", "com.google")
+            .putString("gfs_id", "123")
+            .putString("gfs_token", "token")
+            .putString("device_config", "config")
+            .commit()
+
+        Preferences.migrateDeviceRegistrationPreferences(
+            legacyPreferences,
+            devicePreferences,
+            isSameDeviceUpgrade = true,
+            wasRestored = true
+        )
+
+        assertFalse(devicePreferences.contains("account_name"))
+        assertFalse(devicePreferences.contains("gfs_id"))
+        assertFalse(legacyPreferences.contains("account_name"))
+        assertFalse(legacyPreferences.contains("gfs_id"))
+    }
+
+    @Test
+    fun signedLegacyDeviceIdIsNormalizedToUnsignedHex() {
+        assertEquals(
+            "ffffffffffffffff",
+            Preferences.normalizeDeviceId("-1")
+        )
+        assertEquals("", Preferences.normalizeDeviceId("not-a-device-id"))
+        assertEquals("", Preferences.normalizeDeviceId("0"))
+        assertEquals("", Preferences.normalizeDeviceId("0000000000000000"))
+    }
+
+    @Test
+    fun incompleteAndroid15AccountRequiresExplicitRegistration() {
+        preferences.account = account()
+        assertTrue(preferences.isDeviceRegistrationRequired)
+
+        preferences.account = account(gfsId = "4d2")
+        assertFalse(preferences.isDeviceRegistrationRequired)
+    }
+
+    private fun testPreferences(name: String) =
+        ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences(name, Context.MODE_PRIVATE)
+            .also { it.edit().clear().commit() }
+
+    private fun account(
+        gfsId: String = "",
+        gfsToken: String = "",
+        deviceConfig: String = ""
+    ) = AuthAccount(
+        name = "account@example.com",
+        type = AuthTokenBlocking.ACCOUNT_TYPE,
+        gfsId = gfsId,
+        gfsIdToken = gfsToken,
+        deviceConfig = deviceConfig
+    )
+}

--- a/app/src/test/java/com/anod/appwatcher/accounts/FakeDfeApi.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/FakeDfeApi.kt
@@ -16,7 +16,7 @@ internal class FakeDfeApi : DfeApi {
     var checkInCalls = 0
     var uploadCalls = 0
     var detailsCalls = 0
-    val uploadIdentities = mutableListOf<DfeDeviceIdentity?>()
+    val uploadIdentities = mutableListOf<DfeDeviceIdentity>()
     val detailsFailures = ArrayDeque<Throwable>()
     val checkInFailures = ArrayDeque<Throwable>()
     val uploadFailures = ArrayDeque<Throwable>()
@@ -66,7 +66,7 @@ internal class FakeDfeApi : DfeApi {
         return checkInResponse
     }
 
-    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity?): UploadDeviceConfigResponse {
+    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity): UploadDeviceConfigResponse {
         uploadCalls++
         uploadIdentities.add(identity)
         if (uploadFailures.isNotEmpty()) {

--- a/app/src/test/java/com/anod/appwatcher/accounts/FakeDfeApi.kt
+++ b/app/src/test/java/com/anod/appwatcher/accounts/FakeDfeApi.kt
@@ -1,0 +1,78 @@
+package com.anod.appwatcher.accounts
+
+import finsky.api.BulkDocId
+import finsky.api.DfeApi
+import finsky.api.DfeDeviceIdentity
+import finsky.api.PatchFormat
+import finsky.protos.AndroidCheckinResponse
+import finsky.protos.DeliveryResponse
+import finsky.protos.Details
+import finsky.protos.ResponseWrapper
+import finsky.protos.UploadDeviceConfigResponse
+import java.util.ArrayDeque
+
+internal class FakeDfeApi : DfeApi {
+    override val authenticated = true
+    var checkInCalls = 0
+    var uploadCalls = 0
+    var detailsCalls = 0
+    val uploadIdentities = mutableListOf<DfeDeviceIdentity?>()
+    val detailsFailures = ArrayDeque<Throwable>()
+    val checkInFailures = ArrayDeque<Throwable>()
+    val uploadFailures = ArrayDeque<Throwable>()
+    var uploadFailure: Throwable? = null
+    var detailsResponse: Details.DetailsResponse? = null
+    var beforeCheckIn: suspend () -> Unit = {}
+    var checkInResponse: AndroidCheckinResponse = AndroidCheckinResponse.newBuilder()
+        .setAndroidId(1234L)
+        .setDeviceCheckinConsistencyToken("checkin-token")
+        .build()
+    var uploadResponse: UploadDeviceConfigResponse = UploadDeviceConfigResponse.newBuilder()
+        .setUploadDeviceConfigToken("config-token")
+        .build()
+
+    override suspend fun search(initialQuery: String, nextPageUrl: String): ResponseWrapper =
+        error("Unused")
+
+    override suspend fun details(appDetailsUrl: String): Details.DetailsResponse {
+        detailsCalls++
+        if (detailsFailures.isNotEmpty()) {
+            throw detailsFailures.removeFirst()
+        }
+        return detailsResponse ?: error("Details response not configured")
+    }
+
+    override suspend fun details(docIds: List<BulkDocId>, includeDetails: Boolean): Details.BulkDetailsResponse =
+        error("Unused")
+
+    override suspend fun delivery(
+        docId: String,
+        installedVersionCode: Int,
+        updateVersionCode: Int,
+        offerType: Int,
+        patchFormats: Array<PatchFormat>
+    ): DeliveryResponse = error("Unused")
+
+    override suspend fun wishlist(nextPageUrl: String): ResponseWrapper = error("Unused")
+
+    override suspend fun purchaseHistory(nextPageUrl: String): ResponseWrapper = error("Unused")
+
+    override suspend fun checkIn(): AndroidCheckinResponse {
+        beforeCheckIn()
+        checkInCalls++
+        if (checkInFailures.isNotEmpty()) {
+            throw checkInFailures.removeFirst()
+        }
+        return checkInResponse
+    }
+
+    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity?): UploadDeviceConfigResponse {
+        uploadCalls++
+        uploadIdentities.add(identity)
+        if (uploadFailures.isNotEmpty()) {
+            throw uploadFailures.removeFirst()
+        }
+        uploadFailure?.let { throw it }
+        return uploadResponse
+    }
+}

--- a/app/src/test/java/com/anod/appwatcher/database/AppListTableRoomTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/database/AppListTableRoomTest.kt
@@ -1,14 +1,19 @@
 package com.anod.appwatcher.database
 
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import android.provider.BaseColumns
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.anod.appwatcher.database.entities.App
+import com.anod.appwatcher.database.entities.AppChange
 import com.anod.appwatcher.database.entities.Price
 import com.anod.appwatcher.database.entities.Tag
 import com.anod.appwatcher.preferences.Preferences
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -53,6 +58,114 @@ class AppListTableRoomTest {
         assertEquals(listOf("beta"), loadIds(tagId = 2, titleFilter = "Bet"))
         assertEquals(listOf("gamma"), loadIds(tagId = Tag.empty.id, titleFilter = "Gam"))
     }
+
+    @Test
+    fun syncUpdatesRollBackWhenAnAppWasDeleted() = runBlocking {
+        insertApp(appId = "active", title = "Active")
+        insertApp(appId = "deleted", title = "Deleted", status = App.STATUS_DELETED)
+        val activeApp = db.apps().loadApp("active")!!
+        val deletedApp = db.apps().loadApp("deleted")!!
+        val activeValues = ContentValues().apply {
+            put(BaseColumns._ID, activeApp.rowId)
+            put(AppListTable.Columns.STATUS, App.STATUS_UPDATED)
+        }
+        val deletedValues = ContentValues().apply {
+            put(BaseColumns._ID, deletedApp.rowId)
+            put(AppListTable.Columns.STATUS, App.STATUS_NORMAL)
+        }
+
+        try {
+            db.applyAppSyncUpdates(
+                listOf(
+                    syncUpdate(activeApp, activeValues),
+                    syncUpdate(deletedApp, deletedValues)
+                )
+            )
+            throw AssertionError("Expected synchronization conflict")
+        } catch (_: IllegalStateException) {
+        }
+
+        assertEquals(App.STATUS_NORMAL, db.apps().loadAppRow(activeApp.rowId)?.status)
+        assertEquals(App.STATUS_DELETED, db.apps().loadAppRow(deletedApp.rowId)?.status)
+        assertTrue(db.changelog().ofApp("active").isEmpty())
+        assertTrue(db.changelog().ofApp("deleted").isEmpty())
+    }
+
+    @Test
+    fun syncUpdatesCommitAppAndChangelogTogether() = runBlocking {
+        insertApp(appId = "active", title = "Active")
+        val activeApp = db.apps().loadApp("active")!!
+        val values = ContentValues().apply {
+            put(BaseColumns._ID, activeApp.rowId)
+            put(AppListTable.Columns.STATUS, App.STATUS_UPDATED)
+            put(AppListTable.Columns.VERSION_NUMBER, 2)
+        }
+
+        db.applyAppSyncUpdates(listOf(syncUpdate(activeApp, values)))
+
+        assertEquals(App.STATUS_UPDATED, db.apps().loadAppRow(activeApp.rowId)?.status)
+        assertEquals(2, db.apps().loadAppRow(activeApp.rowId)?.versionNumber)
+        assertEquals(listOf(2), db.changelog().ofApp("active").map { it.versionCode })
+    }
+
+    @Test
+    fun syncUpdatesRollBackWhenAppRowIdentityChanged() = runBlocking {
+        insertApp(appId = "first", title = "First")
+        insertApp(appId = "second", title = "Second")
+        val firstApp = db.apps().loadApp("first")!!
+        val secondApp = db.apps().loadApp("second")!!
+        val firstValues = ContentValues().apply {
+            put(BaseColumns._ID, firstApp.rowId)
+            put(AppListTable.Columns.STATUS, App.STATUS_UPDATED)
+        }
+        val secondValues = ContentValues().apply {
+            put(BaseColumns._ID, secondApp.rowId)
+            put(AppListTable.Columns.STATUS, App.STATUS_UPDATED)
+        }
+        db.openHelper.writableDatabase.update(
+            AppListTable.TABLE,
+            SQLiteDatabase.CONFLICT_ABORT,
+            ContentValues().apply {
+                put(AppListTable.Columns.APP_ID, "replacement")
+                put(AppListTable.Columns.PACKAGE_NAME, "replacement.package")
+            },
+            "${BaseColumns._ID}=?",
+            arrayOf<Any>(secondApp.rowId)
+        )
+
+        try {
+            db.applyAppSyncUpdates(
+                listOf(
+                    syncUpdate(firstApp, firstValues),
+                    syncUpdate(secondApp, secondValues)
+                )
+            )
+            throw AssertionError("Expected synchronization conflict")
+        } catch (_: IllegalStateException) {
+        }
+
+        assertEquals(App.STATUS_NORMAL, db.apps().loadAppRow(firstApp.rowId)?.status)
+        assertEquals("replacement", db.apps().loadAppRow(secondApp.rowId)?.appId)
+        assertTrue(db.changelog().ofApp("first").isEmpty())
+        assertTrue(db.changelog().ofApp("second").isEmpty())
+    }
+
+    private fun syncUpdate(app: App, values: ContentValues) = AppSyncUpdate(
+        rowId = app.rowId.toLong(),
+        expectedAppId = app.appId,
+        expectedPackageName = app.packageName,
+        values = values,
+        changelogValues = changelog(app.appId)
+    )
+
+    private fun changelog(appId: String): ContentValues = AppChange(
+        appId = appId,
+        versionCode = 2,
+        versionName = "2.0",
+        details = "",
+        uploadDate = "",
+        noNewDetails = false
+    ).contentValues
 
     private suspend fun insertApp(appId: String, title: String, status: Int = App.STATUS_NORMAL) {
         AppListTable.Queries.insert(

--- a/app/src/test/java/com/anod/appwatcher/database/AppListTableRoomTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/database/AppListTableRoomTest.kt
@@ -60,7 +60,7 @@ class AppListTableRoomTest {
     }
 
     @Test
-    fun syncUpdatesRollBackWhenAnAppWasDeleted() = runBlocking {
+    fun syncUpdatesSkipDeletedAppWithoutRollingBackOthers() = runBlocking {
         insertApp(appId = "active", title = "Active")
         insertApp(appId = "deleted", title = "Deleted", status = App.STATUS_DELETED)
         val activeApp = db.apps().loadApp("active")!!
@@ -74,20 +74,18 @@ class AppListTableRoomTest {
             put(AppListTable.Columns.STATUS, App.STATUS_NORMAL)
         }
 
-        try {
-            db.applyAppSyncUpdates(
-                listOf(
-                    syncUpdate(activeApp, activeValues),
-                    syncUpdate(deletedApp, deletedValues)
-                )
-            )
-            throw AssertionError("Expected synchronization conflict")
-        } catch (_: IllegalStateException) {
-        }
+        val appliedRowIds = AppListTable.Queries.applySyncUpdates(
+            listOf(
+                syncUpdate(activeApp, activeValues),
+                syncUpdate(deletedApp, deletedValues)
+            ),
+            db
+        )
 
-        assertEquals(App.STATUS_NORMAL, db.apps().loadAppRow(activeApp.rowId)?.status)
+        assertEquals(setOf(activeApp.rowId.toLong()), appliedRowIds)
+        assertEquals(App.STATUS_UPDATED, db.apps().loadAppRow(activeApp.rowId)?.status)
         assertEquals(App.STATUS_DELETED, db.apps().loadAppRow(deletedApp.rowId)?.status)
-        assertTrue(db.changelog().ofApp("active").isEmpty())
+        assertEquals(listOf(2), db.changelog().ofApp("active").map { it.versionCode })
         assertTrue(db.changelog().ofApp("deleted").isEmpty())
     }
 
@@ -101,7 +99,7 @@ class AppListTableRoomTest {
             put(AppListTable.Columns.VERSION_NUMBER, 2)
         }
 
-        db.applyAppSyncUpdates(listOf(syncUpdate(activeApp, values)))
+        AppListTable.Queries.applySyncUpdates(listOf(syncUpdate(activeApp, values)), db)
 
         assertEquals(App.STATUS_UPDATED, db.apps().loadAppRow(activeApp.rowId)?.status)
         assertEquals(2, db.apps().loadAppRow(activeApp.rowId)?.versionNumber)
@@ -109,7 +107,7 @@ class AppListTableRoomTest {
     }
 
     @Test
-    fun syncUpdatesRollBackWhenAppRowIdentityChanged() = runBlocking {
+    fun syncUpdatesSkipChangedIdentityWithoutRollingBackOthers() = runBlocking {
         insertApp(appId = "first", title = "First")
         insertApp(appId = "second", title = "Second")
         val firstApp = db.apps().loadApp("first")!!
@@ -133,20 +131,18 @@ class AppListTableRoomTest {
             arrayOf<Any>(secondApp.rowId)
         )
 
-        try {
-            db.applyAppSyncUpdates(
-                listOf(
-                    syncUpdate(firstApp, firstValues),
-                    syncUpdate(secondApp, secondValues)
-                )
-            )
-            throw AssertionError("Expected synchronization conflict")
-        } catch (_: IllegalStateException) {
-        }
+        val appliedRowIds = AppListTable.Queries.applySyncUpdates(
+            listOf(
+                syncUpdate(firstApp, firstValues),
+                syncUpdate(secondApp, secondValues)
+            ),
+            db
+        )
 
-        assertEquals(App.STATUS_NORMAL, db.apps().loadAppRow(firstApp.rowId)?.status)
+        assertEquals(setOf(firstApp.rowId.toLong()), appliedRowIds)
+        assertEquals(App.STATUS_UPDATED, db.apps().loadAppRow(firstApp.rowId)?.status)
         assertEquals("replacement", db.apps().loadAppRow(secondApp.rowId)?.appId)
-        assertTrue(db.changelog().ofApp("first").isEmpty())
+        assertEquals(listOf(2), db.changelog().ofApp("first").map { it.versionCode })
         assertTrue(db.changelog().ofApp("second").isEmpty())
     }
 

--- a/app/src/test/java/com/anod/appwatcher/sync/UpdateCheckVersionRollbackTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/sync/UpdateCheckVersionRollbackTest.kt
@@ -1,0 +1,106 @@
+package com.anod.appwatcher.sync
+
+import android.content.ContentValues
+import com.anod.appwatcher.database.AppListTable
+import com.anod.appwatcher.database.entities.App
+import com.anod.appwatcher.database.entities.Price
+import java.io.IOException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UpdateCheckVersionRollbackTest {
+
+    @Test
+    fun lowerMarketVersionClearsUpdateAndRecentState() {
+        val values = ContentValues()
+
+        val rolledBack = reconcileVersionRollback(
+            marketVersionCode = 99,
+            localApp = app(versionNumber = 100),
+            values = values
+        )
+
+        assertTrue(rolledBack)
+        assertEquals(App.STATUS_NORMAL, values.getAsInteger(AppListTable.Columns.STATUS))
+        assertEquals(0L, values.getAsLong(AppListTable.Columns.SYNC_TIMESTAMP))
+    }
+
+    @Test
+    fun equalOrHigherMarketVersionKeepsCurrentState() {
+        val equalValues = ContentValues()
+        val higherValues = ContentValues()
+
+        assertFalse(reconcileVersionRollback(100, app(versionNumber = 100), equalValues))
+        assertFalse(reconcileVersionRollback(101, app(versionNumber = 100), higherValues))
+        assertEquals(0, equalValues.size())
+        assertEquals(0, higherValues.size())
+    }
+
+    @Test
+    fun chunkFailurePreventsApplyingEarlierFetches() = runBlocking {
+        val applied = mutableListOf<Int>()
+        var failedChunkAttempts = 0
+
+        try {
+            val fetched = fetchAllChunks(
+                chunks = listOf(1, 2, 3),
+                initialRetryDelayMillis = 0
+            ) { chunk ->
+                if (chunk == 2) {
+                    failedChunkAttempts++
+                    throw IOException("failed chunk")
+                }
+                "result-$chunk"
+            }
+            fetched.forEach { (chunk, _) -> applied.add(chunk) }
+            throw AssertionError("Expected chunk failure")
+        } catch (_: IOException) {
+        }
+
+        assertEquals(emptyList<Int>(), applied)
+        assertEquals(3, failedChunkAttempts)
+    }
+
+    @Test
+    fun transientChunkFailureIsRetriedBeforeApplying() = runBlocking {
+        var attempts = 0
+
+        val fetched = fetchAllChunks(
+            chunks = listOf(1),
+            initialRetryDelayMillis = 0
+        ) {
+            attempts++
+            if (attempts < 3) {
+                throw IOException("temporary failure")
+            }
+            "result"
+        }
+
+        assertEquals(listOf(1 to "result"), fetched)
+        assertEquals(3, attempts)
+    }
+
+    private fun app(versionNumber: Int) = App(
+        rowId = 1,
+        appId = "com.example.app",
+        packageName = "com.example.app",
+        versionNumber = versionNumber,
+        versionName = versionNumber.toString(),
+        title = "Example",
+        creator = "Example",
+        iconUrl = "",
+        status = App.STATUS_UPDATED,
+        uploadDate = "",
+        price = Price("", "", 0),
+        detailsUrl = null,
+        uploadTime = 0,
+        appType = "",
+        syncTime = System.currentTimeMillis()
+    )
+}

--- a/app/src/test/java/com/anod/appwatcher/sync/UpdateCheckVersionRollbackTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/sync/UpdateCheckVersionRollbackTest.kt
@@ -50,6 +50,7 @@ class UpdateCheckVersionRollbackTest {
         try {
             val fetched = fetchAllChunks(
                 chunks = listOf(1, 2, 3),
+                maxAttempts = UpdateCheck.MAX_CHUNK_ATTEMPTS,
                 initialRetryDelayMillis = 0
             ) { chunk ->
                 if (chunk == 2) {
@@ -73,6 +74,7 @@ class UpdateCheckVersionRollbackTest {
 
         val fetched = fetchAllChunks(
             chunks = listOf(1),
+            maxAttempts = UpdateCheck.MAX_CHUNK_ATTEMPTS,
             initialRetryDelayMillis = 0
         ) {
             attempts++

--- a/playstore/build.gradle.kts
+++ b/playstore/build.gradle.kts
@@ -38,6 +38,13 @@ kotlin {
                 implementation(libs.coroutines.android)
             }
         }
+        getByName("androidHostTest") {
+            dependencies {
+                implementation(libs.junit)
+                implementation(libs.androidx.test.core)
+                implementation(libs.robolectric)
+            }
+        }
     }
 }
 

--- a/playstore/src/androidHostTest/kotlin/finsky/api/DfeApiContextTest.kt
+++ b/playstore/src/androidHostTest/kotlin/finsky/api/DfeApiContextTest.kt
@@ -1,0 +1,106 @@
+package finsky.api
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DfeApiContextTest {
+
+    @Test
+    fun explicitIdentityReplacesPersistedDeviceHeaders() {
+        val apiContext = DfeApiContext(
+            context = ApplicationProvider.getApplicationContext(),
+            authTokenProvider = FakeAuthProvider(),
+            deviceInfo = FakeDeviceInfoProvider()
+        )
+
+        val headers = apiContext.createDefaultHeaders(
+            DfeDeviceIdentity(
+                deviceId = "new-device",
+                deviceCheckinConsistencyToken = "new-checkin"
+            )
+        )
+
+        assertEquals("new-device", headers["X-DFE-Device-Id"])
+        assertEquals("new-checkin", headers["X-DFE-Device-Checkin-Consistency-Token"])
+        assertFalse(headers.containsKey("X-DFE-Device-Config-Token"))
+    }
+
+    @Test
+    fun firstCheckinOmitsPersistedDeviceId() {
+        val apiContext = DfeApiContext(
+            context = ApplicationProvider.getApplicationContext(),
+            authTokenProvider = FakeAuthProvider(),
+            deviceInfo = FakeDeviceInfoProvider()
+        )
+
+        assertFalse(apiContext.createAuthHeaders(includeDeviceId = false).containsKey("device"))
+    }
+
+    private class FakeAuthProvider : DfeAuthProvider {
+        override val gfsId = "old-device"
+        override val gfsToken = "old-checkin"
+        override val authToken = "auth-token"
+        override val accountName = "account@example.com"
+        override val deviceConfigToken = "old-config"
+    }
+
+    private class FakeDeviceInfoProvider : DfeDeviceInfoProvider {
+        override val deviceId = "physical-device"
+        override val simOperator = ""
+        override val cellOperator = ""
+        override val roaming = "mobile-notroaming"
+        override val build: DfeDeviceBuild = FakeDeviceBuild()
+        override val client = "android-google"
+        override val gsfVersion = 1L
+        override val otaInstalled = false
+        override val locale = DfeLocale("en", "US", "en_US")
+        override val timeZone = "UTC"
+        override val configuration: DfeDeviceConfiguration = FakeDeviceConfiguration()
+        override val playVersionCode = 1L
+        override val playVersionName = "1"
+    }
+
+    private class FakeDeviceBuild : DfeDeviceBuild {
+        override val id = "build-id"
+        override val fingerprint = "fingerprint"
+        override val hardware = "hardware"
+        override val brand = "brand"
+        override val radio = "radio"
+        override val bootloader = "bootloader"
+        override val device = "device"
+        override val sdkVersion = 35
+        override val releaseVersion = "15"
+        override val model = "model"
+        override val manifacturer = "manufacturer"
+        override val product = "product"
+        override val abis = arrayOf("arm64-v8a")
+    }
+
+    private class FakeDeviceConfiguration : DfeDeviceConfiguration {
+        override val touchScreen = 3
+        override val keyboard = 1
+        override val navigation = 1
+        override val screenLayout = 2
+        override val hasHardKeyboard = false
+        override val hasFiveWayNavigation = false
+        override val lowRamDevice = 0
+        override val maxNumOfCPUCores = 8
+        override val totalMemoryBytes = 8_000_000_000L
+        override val deviceClass = 0
+        override val screenDensity = 420
+        override val screenWidth = 1080
+        override val screenHeight = 2400
+        override val sharedLibraries = emptyList<String>()
+        override val features = emptyList<String>()
+        override val locales = listOf("en_US")
+        override val glEsVersion = 0
+        override val glExtensions = emptyList<String>()
+        override val isWideScreen = false
+    }
+}

--- a/playstore/src/androidHostTest/kotlin/finsky/api/DfeApiContextTest.kt
+++ b/playstore/src/androidHostTest/kotlin/finsky/api/DfeApiContextTest.kt
@@ -7,8 +7,10 @@ import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
 class DfeApiContextTest {
 
     @Test
@@ -22,7 +24,8 @@ class DfeApiContextTest {
         val headers = apiContext.createDefaultHeaders(
             DfeDeviceIdentity(
                 deviceId = "new-device",
-                deviceCheckinConsistencyToken = "new-checkin"
+                deviceCheckinConsistencyToken = "new-checkin",
+                deviceConfigToken = ""
             )
         )
 

--- a/playstore/src/androidMain/java/finsky/api/DfeApi.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeApi.kt
@@ -109,7 +109,7 @@ data class DfeAuthData(
 data class DfeDeviceIdentity(
     val deviceId: String,
     val deviceCheckinConsistencyToken: String,
-    val deviceConfigToken: String = ""
+    val deviceConfigToken: String
 )
 
 interface DfeApi {
@@ -139,7 +139,7 @@ interface DfeApi {
 
     suspend fun checkIn(): AndroidCheckinResponse
 
-    suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity? = null): UploadDeviceConfigResponse
+    suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity): UploadDeviceConfigResponse
 
     companion object {
         const val URL_BASE = "https://android.clients.google.com"

--- a/playstore/src/androidMain/java/finsky/api/DfeApi.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeApi.kt
@@ -88,7 +88,29 @@ interface DfeAuthProvider {
     val authToken: String
     val accountName: String
     val deviceConfigToken: String
+    val authData: DfeAuthData
+        get() = DfeAuthData(
+            gfsId = gfsId,
+            gfsToken = gfsToken,
+            authToken = authToken,
+            accountName = accountName,
+            deviceConfigToken = deviceConfigToken
+        )
 }
+
+data class DfeAuthData(
+    val gfsId: String,
+    val gfsToken: String,
+    val authToken: String,
+    val accountName: String,
+    val deviceConfigToken: String
+)
+
+data class DfeDeviceIdentity(
+    val deviceId: String,
+    val deviceCheckinConsistencyToken: String,
+    val deviceConfigToken: String = ""
+)
 
 interface DfeApi {
     val authenticated: Boolean
@@ -117,7 +139,7 @@ interface DfeApi {
 
     suspend fun checkIn(): AndroidCheckinResponse
 
-    suspend fun uploadDeviceConfig(): UploadDeviceConfigResponse
+    suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity? = null): UploadDeviceConfigResponse
 
     companion object {
         const val URL_BASE = "https://android.clients.google.com"

--- a/playstore/src/androidMain/java/finsky/api/DfeApiContext.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeApiContext.kt
@@ -12,7 +12,7 @@ class DfeApiContext private constructor(
     loggingId: String
 ) {
     val hasAuth: Boolean
-        get() = authTokenProvider.authToken.isNotEmpty() && authTokenProvider.accountName.isNotEmpty()
+        get() = authTokenProvider.authData.let { it.authToken.isNotEmpty() && it.accountName.isNotEmpty() }
 
     private val headers: MutableMap<String, String> = mutableMapOf(
         "Accept-Language" to deviceInfo.locale.acceptLanguage,
@@ -39,22 +39,25 @@ class DfeApiContext private constructor(
         }
     }
 
-    internal fun createDefaultHeaders(): MutableMap<String, String> {
-        val authToken = authTokenProvider.authToken
-        if (authToken.isBlank()) {
+    internal fun createDefaultHeaders(identity: DfeDeviceIdentity? = null): MutableMap<String, String> {
+        val authData = authTokenProvider.authData
+        if (authData.authToken.isBlank()) {
             throw IllegalStateException("Auth token is empty")
         }
         synchronized(this) {
             val hashMap = this.headers.toMutableMap()
-            hashMap["X-DFE-Device-Id"] = authTokenProvider.gfsId.ifEmpty { deviceInfo.deviceId }
-            if (authTokenProvider.gfsToken.isNotBlank()) {
-                hashMap["X-DFE-Device-Checkin-Consistency-Token"] = authTokenProvider.gfsToken
+            hashMap["X-DFE-Device-Id"] = identity?.deviceId ?: authData.gfsId.ifEmpty { deviceInfo.deviceId }
+            val deviceCheckinConsistencyToken =
+                identity?.deviceCheckinConsistencyToken ?: authData.gfsToken
+            if (deviceCheckinConsistencyToken.isNotBlank()) {
+                hashMap["X-DFE-Device-Checkin-Consistency-Token"] = deviceCheckinConsistencyToken
             }
-            if (authTokenProvider.deviceConfigToken.isNotBlank()) {
-                hashMap["X-DFE-Device-Config-Token"] = authTokenProvider.deviceConfigToken
+            val deviceConfigToken = identity?.deviceConfigToken ?: authData.deviceConfigToken
+            if (deviceConfigToken.isNotBlank()) {
+                hashMap["X-DFE-Device-Config-Token"] = deviceConfigToken
             }
             hashMap["X-DFE-Network-Type"] = NetworkStateChangedReceiver.getCachedNetworkType(context).value.toString()
-            hashMap["Authorization"] = "GoogleLogin auth=${authToken}"
+            hashMap["Authorization"] = "GoogleLogin auth=${authData.authToken}"
             return hashMap
         }
     }
@@ -63,13 +66,14 @@ class DfeApiContext private constructor(
         return "[PlayDfeApiContext headers={${this.headers.map { "${it.key} = ${it.value}," }}]"
     }
 
-    fun createAuthHeaders(): MutableMap<String, String> {
+    fun createAuthHeaders(includeDeviceId: Boolean = true): MutableMap<String, String> {
+        val authData = authTokenProvider.authData
         return mutableMapOf(
             "app" to "com.google.android.gms",
             "User-Agent" to "GoogleAuth/1.4 (${deviceInfo.build.device} ${deviceInfo.build.id})",
         ).apply {
-            if (authTokenProvider.gfsId.isNotEmpty()) {
-                this["device"] = authTokenProvider.gfsId
+            if (includeDeviceId && authData.gfsId.isNotEmpty()) {
+                this["device"] = authData.gfsId
             }
         }
     }

--- a/playstore/src/androidMain/java/finsky/api/DfeApiContext.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeApiContext.kt
@@ -39,7 +39,7 @@ class DfeApiContext private constructor(
         }
     }
 
-    internal fun createDefaultHeaders(identity: DfeDeviceIdentity? = null): MutableMap<String, String> {
+    internal fun createDefaultHeaders(identity: DfeDeviceIdentity?): MutableMap<String, String> {
         val authData = authTokenProvider.authData
         if (authData.authToken.isBlank()) {
             throw IllegalStateException("Auth token is empty")
@@ -66,7 +66,7 @@ class DfeApiContext private constructor(
         return "[PlayDfeApiContext headers={${this.headers.map { "${it.key} = ${it.value}," }}]"
     }
 
-    fun createAuthHeaders(includeDeviceId: Boolean = true): MutableMap<String, String> {
+    fun createAuthHeaders(includeDeviceId: Boolean): MutableMap<String, String> {
         val authData = authTokenProvider.authData
         return mutableMapOf(
             "app" to "com.google.android.gms",

--- a/playstore/src/androidMain/java/finsky/api/DfeApiImpl.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeApiImpl.kt
@@ -122,7 +122,7 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
             .url(URL_CHECK_IN)
             .apply {
                 post(checkin.toByteArray().toRequestBody("application/x-protobuf".toMediaType()))
-                apiContext.createAuthHeaders().forEach {
+                apiContext.createAuthHeaders(includeDeviceId = false).forEach {
                     addHeader(it.key, it.value)
                 }
                 addHeader("Host", "android.clients.google.com")
@@ -131,12 +131,12 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
         return newCall(dfeRequest) { AndroidCheckinResponse.parseFrom(it) }
     }
 
-    override suspend fun uploadDeviceConfig(): UploadDeviceConfigResponse {
+    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity?): UploadDeviceConfigResponse {
         val request = UploadDeviceConfigRequest.newBuilder()
             .setDeviceConfiguration(apiContext.deviceInfo.configuration.toProto(apiContext.deviceInfo.build.abis))
             .build()
 
-        val dfeRequest = createRequest(DfeApi.URL_UPLOAD_DEVICE_CONFIG) { builder ->
+        val dfeRequest = createRequest(DfeApi.URL_UPLOAD_DEVICE_CONFIG, identity) { builder ->
             builder.post(request.toByteArray().toRequestBody("application/x-protobuf".toMediaType()))
         }
         val response = newCall(dfeRequest)
@@ -162,12 +162,18 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
                 try {
                     response.body?.use { body ->
                         if (!response.isSuccessful) {
-                            DfeResponse().parseNetworkError(body.byteStream())
-                            if (response.code == HttpURLConnection.HTTP_NOT_FOUND) {
-                                throw DfeServerError("Not Found")
-                            } else {
-                                throw DfeServerError("Status code ${response.code}")
+                            var error: Exception? = null
+                            try {
+                                DfeResponse().parseNetworkError(body.byteStream())
+                            } catch (e: Exception) {
+                                error = e
                             }
+                            val message = when {
+                                error is DfeServerError -> error.message ?: "Status code ${response.code}"
+                                response.code == HttpURLConnection.HTTP_NOT_FOUND -> "Not Found"
+                                else -> "Status code ${response.code}"
+                            }
+                            throw DfeServerError(message, response.code, error)
                         } else {
                             val parsed = responseParser(body.byteStream())
                             continuation.resume(parsed)
@@ -182,7 +188,11 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
         continuation.invokeOnCancellation { call.cancel() }
     }
 
-    private fun createRequest(url: String, customizer: ((Request.Builder) -> Unit)? = null): Request {
+    private fun createRequest(
+        url: String,
+        identity: DfeDeviceIdentity? = null,
+        customizer: ((Request.Builder) -> Unit)? = null
+    ): Request {
         return Request.Builder()
                 .url(url)
                 .apply {
@@ -191,7 +201,7 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
                     } else {
                         customizer(this)
                     }
-                    apiContext.createDefaultHeaders().forEach { entry ->
+                    apiContext.createDefaultHeaders(identity).forEach { entry ->
                         addHeader(entry.key, entry.value)
                     }
                 }

--- a/playstore/src/androidMain/java/finsky/api/DfeApiImpl.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeApiImpl.kt
@@ -52,12 +52,16 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
                     .build().toString()
             else
                 DfeApi.URL_FDFE + "/" + nextPageUrl
-        val dfeRequest = createRequest(url)
+        val dfeRequest = createRequest(url, identity = null, customizer = null)
         return newCall(dfeRequest)
     }
 
     override suspend fun details(appDetailsUrl: String): DetailsResponse {
-        val dfeRequest = createRequest(DfeApi.URL_FDFE + "/" + appDetailsUrl)
+        val dfeRequest = createRequest(
+            DfeApi.URL_FDFE + "/" + appDetailsUrl,
+            identity = null,
+            customizer = null
+        )
         val responseWrapper = newCall(dfeRequest)
         return responseWrapper.payload.detailsResponse
     }
@@ -68,7 +72,7 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
                 .addAllDocid(docIds.map { it.packageName }.sorted())
                 .build()
 
-        val dfeRequest = createRequest(DfeApi.BULK_DETAILS_URI) { builder ->
+        val dfeRequest = createRequest(DfeApi.BULK_DETAILS_URI, identity = null) { builder ->
             builder.post(bulkDetailsRequest.toByteArray().toRequestBody("application/x-protobuf".toMediaType()))
         }
 
@@ -89,7 +93,7 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
             .addQueryParameter("vc", updateVersionCode.toString())
             .build().toString()
 
-        val dfeRequest = createRequest(url)
+        val dfeRequest = createRequest(url, identity = null, customizer = null)
         val responseWrapper = newCall(dfeRequest)
         return responseWrapper.payload.deliveryResponse
     }
@@ -100,7 +104,7 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
                 createLibraryUrl(DfeApi.wishlistBackendId, libraryId, 7, null)
             else
                 DfeApi.URL_FDFE + "/" + nextPageUrl
-        val dfeRequest = createRequest(url)
+        val dfeRequest = createRequest(url, identity = null, customizer = null)
         return newCall(dfeRequest)
     }
 
@@ -109,7 +113,7 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
             DfeApi.PURCHASE_HISTORY_URL + "?o=0"
         else
             DfeApi.URL_FDFE + "/" + nextPageUrl
-        val dfeRequest = createRequest(url)
+        val dfeRequest = createRequest(url, identity = null, customizer = null)
         return newCall(dfeRequest)
     }
 
@@ -131,7 +135,7 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
         return newCall(dfeRequest) { AndroidCheckinResponse.parseFrom(it) }
     }
 
-    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity?): UploadDeviceConfigResponse {
+    override suspend fun uploadDeviceConfig(identity: DfeDeviceIdentity): UploadDeviceConfigResponse {
         val request = UploadDeviceConfigRequest.newBuilder()
             .setDeviceConfiguration(apiContext.deviceInfo.configuration.toProto(apiContext.deviceInfo.build.abis))
             .build()
@@ -190,8 +194,8 @@ class DfeApiImpl(private val http: OkHttpClient, private val apiContext: DfeApiC
 
     private fun createRequest(
         url: String,
-        identity: DfeDeviceIdentity? = null,
-        customizer: ((Request.Builder) -> Unit)? = null
+        identity: DfeDeviceIdentity?,
+        customizer: ((Request.Builder) -> Unit)?
     ): Request {
         return Request.Builder()
                 .url(url)

--- a/playstore/src/androidMain/java/finsky/api/DfeResponse.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeResponse.kt
@@ -68,7 +68,11 @@ class DfeResponse {
                 AppLog.d(commands.logErrorStacktrace)
             }
             if (!TextUtils.isEmpty(commands.displayErrorMessage)) {
-                throw DfeServerError(commands.displayErrorMessage)
+                throw DfeServerError(
+                    message = commands.displayErrorMessage,
+                    statusCode = null,
+                    cause = null
+                )
             }
         }
     }

--- a/playstore/src/androidMain/java/finsky/api/DfeServerError.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeServerError.kt
@@ -11,8 +11,8 @@ class DfeParseError(message: String, cause: Throwable? = null) : DfeError(messag
 
 class DfeServerError(
     message: String,
-    val statusCode: Int? = null,
-    cause: Throwable? = null
+    val statusCode: Int?,
+    cause: Throwable?
 ) : DfeError(message, cause) {
     val isAuthenticationError: Boolean
         get() = statusCode == 401 || statusCode == 403

--- a/playstore/src/androidMain/java/finsky/api/DfeServerError.kt
+++ b/playstore/src/androidMain/java/finsky/api/DfeServerError.kt
@@ -9,7 +9,14 @@ class DfeParseError(message: String, cause: Throwable? = null) : DfeError(messag
 
 }
 
-class DfeServerError(message: String) : DfeError(message) {
+class DfeServerError(
+    message: String,
+    val statusCode: Int? = null,
+    cause: Throwable? = null
+) : DfeError(message, cause) {
+    val isAuthenticationError: Boolean
+        get() = statusCode == 401 || statusCode == 403
+
     override fun toString(): String {
         return "DisplayErrorMessage[$message]"
     }


### PR DESCRIPTION
## Summary
- persist and reuse one Play device identity, restricting new Android 15+ check-ins to explicit account recovery
- make registration cancellation-safe and exclude device credentials from backup and device transfer while preserving normal Auto Backup
- centralize one-shot authentication recovery with coherent account, token, and device headers
- serialize update checks, retry transient chunks, and atomically apply identity-matched app and changelog updates
- preserve state for omitted Play documents and clear stale updates when Play returns a lower version

## Testing
- `:app:testDebugUnitTest`
- `:playstore:testAndroidHostTest`
- `:app:lintDebug`
- `ktlintCheck`
- `:app:compileDebugAndroidTestKotlin`

Fixes #107