### PR TITLE
Refresh local versions on watchlist refresh

### DIFF
--- a/app/src/main/java/com/anod/appwatcher/details/AppItemState.kt
+++ b/app/src/main/java/com/anod/appwatcher/details/AppItemState.kt
@@ -34,7 +34,7 @@ fun rememberAppItemState(
     primaryColor: Color = MaterialTheme.colorScheme.primary
 ): AppItemState {
     val context = LocalContext.current
-    return remember(app) {
+    return remember(app, recentFlag, packageInfo, textColor, primaryColor, context) {
         calcAppItemState(
             app, recentFlag, textColor, primaryColor, packageInfo, context
         )

--- a/app/src/main/java/com/anod/appwatcher/watchlist/Section.kt
+++ b/app/src/main/java/com/anod/appwatcher/watchlist/Section.kt
@@ -66,7 +66,7 @@ sealed interface SectionItem {
         override val contentType = "App"
         val changesHtml: String = appListItem.cleanChangeHtml()
 
-        override fun hashCode(): Int = hashCodeOf("SectionItem.App", appListItem, isLocal)
+        override fun hashCode(): Int = hashCodeOf("SectionItem.App", appListItem, isLocal, packageInfo)
 
         override fun equals(other: Any?): Boolean {
             val item = other as? App ?: return false
@@ -80,7 +80,7 @@ sealed interface SectionItem {
         override val contentType = "OnDevice"
         val changesHtml: String = appListItem.cleanChangeHtml()
 
-        override fun hashCode(): Int = hashCodeOf("SectionItem.OnDevice", appListItem, showSelection)
+        override fun hashCode(): Int = hashCodeOf("SectionItem.OnDevice", appListItem, showSelection, packageInfo)
 
         override fun equals(other: Any?): Boolean {
             val item = other as? OnDevice ?: return false

--- a/app/src/main/java/com/anod/appwatcher/watchlist/WatchListStateViewModel.kt
+++ b/app/src/main/java/com/anod/appwatcher/watchlist/WatchListStateViewModel.kt
@@ -412,11 +412,12 @@ class WatchListStateViewModel(
             throw IllegalStateException("auth token is invalid")
         }
 
+        installedApps.reset()
+        invalidatePagingSources()
         viewState = viewState.copy(
             syncProgress = SyncProgress(true, 0),
             refreshRequest = viewState.refreshRequest + 1
         )
-        installedApps.reset()
         SyncScheduler(application).execute().first()
     }
 

--- a/app/src/test/java/com/anod/appwatcher/utils/InstalledAppsMemoryCacheTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/utils/InstalledAppsMemoryCacheTest.kt
@@ -1,0 +1,73 @@
+package com.anod.appwatcher.utils
+
+import info.anodsplace.framework.content.InstalledApps
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InstalledAppsMemoryCacheTest {
+
+    @Test
+    fun `reset loads package info from a new cache generation`() {
+        val versionCode = AtomicInteger(1)
+        val reads = AtomicInteger()
+        val cache = InstalledApps.MemoryCache(object : InstalledApps {
+            override fun packageInfo(packageName: String): InstalledApps.Info {
+                reads.incrementAndGet()
+                val version = versionCode.get()
+                return InstalledApps.Info(versionCode = version, versionName = version.toString())
+            }
+        })
+
+        assertEquals(1, cache.packageInfo(PACKAGE_NAME).versionCode)
+        versionCode.set(2)
+        assertEquals(1, cache.packageInfo(PACKAGE_NAME).versionCode)
+
+        cache.reset()
+
+        assertEquals(2, cache.packageInfo(PACKAGE_NAME).versionCode)
+        assertEquals(2, reads.get())
+    }
+
+    @Test
+    fun `in flight read cannot populate cache generation created by reset`() {
+        val firstReadStarted = CountDownLatch(1)
+        val releaseFirstRead = CountDownLatch(1)
+        val reads = AtomicInteger()
+        val cache = InstalledApps.MemoryCache(object : InstalledApps {
+            override fun packageInfo(packageName: String): InstalledApps.Info {
+                val read = reads.incrementAndGet()
+                if (read == 1) {
+                    firstReadStarted.countDown()
+                    check(releaseFirstRead.await(5, TimeUnit.SECONDS))
+                }
+                return InstalledApps.Info(versionCode = read, versionName = read.toString())
+            }
+        })
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val firstRead = executor.submit<InstalledApps.Info> {
+                cache.packageInfo(PACKAGE_NAME)
+            }
+            check(firstReadStarted.await(5, TimeUnit.SECONDS))
+
+            cache.reset()
+            releaseFirstRead.countDown()
+
+            assertEquals(1, firstRead.get(5, TimeUnit.SECONDS).versionCode)
+            assertEquals(2, cache.packageInfo(PACKAGE_NAME).versionCode)
+            assertEquals(2, reads.get())
+        } finally {
+            releaseFirstRead.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    private companion object {
+        const val PACKAGE_NAME = "com.example.app"
+    }
+}

--- a/app/src/test/java/com/anod/appwatcher/watchlist/SectionItemTest.kt
+++ b/app/src/test/java/com/anod/appwatcher/watchlist/SectionItemTest.kt
@@ -47,6 +47,33 @@ class SectionItemTest {
     }
 
     @Test
+    fun `local version changes update section content without changing identity`() {
+        val app = appSectionItem(
+            rowId = 1,
+            packageName = "com.example.app",
+            packageInfo = InstalledApps.Info(versionCode = 1, versionName = "1")
+        )
+        val updatedApp = appSectionItem(
+            rowId = 1,
+            packageName = "com.example.app",
+            packageInfo = InstalledApps.Info(versionCode = 2, versionName = "2")
+        )
+        val onDevice = onDeviceSectionItem(
+            packageName = "com.example.local",
+            packageInfo = InstalledApps.Info(versionCode = 1, versionName = "1")
+        )
+        val updatedOnDevice = onDeviceSectionItem(
+            packageName = "com.example.local",
+            packageInfo = InstalledApps.Info(versionCode = 2, versionName = "2")
+        )
+
+        assertEquals(app.sectionKey, updatedApp.sectionKey)
+        assertNotEquals(app, updatedApp)
+        assertEquals(onDevice.sectionKey, updatedOnDevice.sectionKey)
+        assertNotEquals(onDevice, updatedOnDevice)
+    }
+
+    @Test
     fun `app section keys stay unique when temporary row ids match`() {
         assertNotEquals(
             appSectionItem(rowId = -1, packageName = "com.example.first").sectionKey,
@@ -97,7 +124,8 @@ class SectionItemTest {
         rowId: Int,
         packageName: String,
         title: String = packageName,
-        versionNumber: Int = 1
+        versionNumber: Int = 1,
+        packageInfo: InstalledApps.Info = InstalledApps.Info(versionCode = 0, versionName = "")
     ): SectionItem.App = SectionItem.App(
         appListItem = appListItem(
             rowId = rowId,
@@ -106,17 +134,18 @@ class SectionItemTest {
             versionNumber = versionNumber
         ),
         isLocal = false,
-        packageInfo = InstalledApps.Info(versionCode = 0, versionName = "")
+        packageInfo = packageInfo
     )
 
     private fun onDeviceSectionItem(
         packageName: String,
         title: String = packageName,
-        showSelection: Boolean = false
+        showSelection: Boolean = false,
+        packageInfo: InstalledApps.Info = InstalledApps.Info(versionCode = 1, versionName = "1")
     ): SectionItem.OnDevice = SectionItem.OnDevice(
         appListItem = appListItem(rowId = -1, packageName = packageName, title = title),
         showSelection = showSelection,
-        packageInfo = InstalledApps.Info(versionCode = 1, versionName = "1")
+        packageInfo = packageInfo
     )
 
     private fun appListItem(


### PR DESCRIPTION
## Summary

Watchlist refresh could continue showing cached installed-version details for apps recently updated on the device. The installed-app cache and cached paging rows both retained the old PackageManager result.

- reset installed-app data before invalidating active paging sources when refresh begins
- include package information in row content equality and Compose state keys while preserving stable list identity
- replace the shared cache with an O(1), generation-swapped `ConcurrentHashMap` so resets are thread-safe and in-flight reads cannot repopulate the new generation
- cover cache reset races and local-version content updates with regression tests

Related: #107

## Testing

- `.\gradlew.bat :app:testDebugUnitTest --tests "com.anod.appwatcher.watchlist.SectionItemTest" --tests "com.anod.appwatcher.utils.InstalledAppsMemoryCacheTest"`
- `.\gradlew.bat ktlintCheck`